### PR TITLE
Regenerate helptags when installing via rake

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -34,6 +34,7 @@ end
 
 desc "Install"
 task :install do
+
   vimfiles = if ENV['VIMFILES']
                ENV['VIMFILES']
              elsif RUBY_PLATFORM =~ /(win|w)32$/
@@ -49,6 +50,13 @@ task :install do
     FileUtils.cp(file, target_file)
     puts "  Copied #{file} to #{target_file}"
   end
+
+  puts "Regenerating helptags"
+  `vim -c 'helptags #{vimfiles}/doc' -c q 2> /dev/null`
+  # '2> /dev/null' to suppress the following message:
+  # "Vim: Warning: Output is not to a terminal"
+  puts "  Processed #{vimfiles}/doc directory"
+
 end
 
 task 'zip' => 'rails.zip'


### PR DESCRIPTION
Hi Tim,

A small addition to the Rakefile, one that also regenerates the helptags when installing the plugin via rake.

Thanks for your consideration.

Peter
