### PR TITLE
Support for custom paths in Sass, Less and Coffee

### DIFF
--- a/autoload/rails.vim
+++ b/autoload/rails.vim
@@ -1001,10 +1001,7 @@ function! s:BufCommands()
   command! -buffer -bar -nargs=0 -bang Rrefresh :if <bang>0|unlet! g:autoloaded_rails|source `=s:file`|endif|call s:Refresh(<bang>0)
   if exists(":NERDTree")
     command! -buffer -bar -nargs=? -complete=customlist,s:Complete_cd Rtree :NERDTree `=rails#app().path(<f-args>)`
-  elseif exists(":Project")
-    command! -buffer -bar -nargs=? Rtree :call s:Project(<bang>0,<q-args>)
   endif
-  command! -buffer -bar -nargs=? Rproject :call s:warn("Warning: :Rproject has been deprecated in favor of :Rtree") | Rtree<bang> <args>
   if exists("g:loaded_dbext")
     command! -buffer -bar -nargs=? -complete=customlist,s:Complete_environments Rdbext  :call s:BufDatabase(2,<q-args>)|let b:dbext_buffer_defaulted = 1
   endif
@@ -1188,6 +1185,7 @@ let s:efm_backtrace='%D(in\ %f),'
       \.'%\\s%#from\ %f:%l:%m,'
       \.'%\\s%#from\ %f:%l:,'
       \.'%\\s#{RAILS_ROOT}/%f:%l:\ %#%m,'
+      \.'%\\s%##\ %f:%l:%m,'
       \.'%\\s%#[%f:%l:\ %#%m,'
       \.'%\\s%#%f:%l:\ %#%m,'
       \.'%\\s%#%f:%l:,'
@@ -1926,7 +1924,7 @@ function! s:findamethod(func,repl)
 endfunction
 
 function! s:findasymbol(sym,repl)
-  return s:findit('\s*:\%('.a:sym.'\)\s*=>\s*(\=\s*[@:'."'".'"]\(\f\+\)\>.\=',a:repl)
+  return s:findit('\s*\%(:\%('.a:sym.'\)\s*=>\|\<'.a:sym.':\)\s*(\=\s*[@:'."'".'"]\(\f\+\)\>.\=',a:repl)
 endfunction
 
 function! s:findfromview(func,repl)
@@ -1981,10 +1979,10 @@ function! s:RailsFind()
   let res = s:findasymbol('to','app/controllers/\1')
   if res =~ '#'|return s:sub(res,'#','_controller.rb#')|endif
 
-  let res = s:findamethod('root\s*:to\s*=>\s*','app/controllers/\1')
+  let res = s:findamethod('root\s*\%(:to\s*=>\|\<to:\)\s*','app/controllers/\1')
   if res =~ '#'|return s:sub(res,'#','_controller.rb#')|endif
 
-  let res = s:findamethod('\%(match\|get\|put\|post\|delete\|redirect\)\s*(\=\s*[:''"][^''"]*[''"]\=\s*\%(,\s*:to\s*\)\==>\s*','app/controllers/\1')
+  let res = s:findamethod('\%(match\|get\|put\|post\|delete\|redirect\)\s*(\=\s*[:''"][^''"]*[''"]\=\s*\%(\%(,\s*:to\s*\)\==>\|,\s*to:\)\s*','app/controllers/\1')
   if res =~ '#'|return s:sub(res,'#','_controller.rb#')|endif
 
   let res = s:findamethod('layout','\=s:findlayout(submatch(1))')
@@ -2005,20 +2003,20 @@ function! s:RailsFind()
   let res = s:findasymbol('template','app/views/\1')
   if res != ""|return res|endif
 
-  let res = s:sub(s:sub(s:findasymbol('partial','\1'),'^/',''),'\k+$','_&')
+  let res = s:sub(s:sub(s:findasymbol('partial','\1'),'^/',''),'[^/]+$','_&')
   if res != ""|return res."\n".s:findview(res)|endif
 
-  let res = s:sub(s:sub(s:findfromview('render\s*(\=\s*:partial\s\+=>\s*','\1'),'^/',''),'\k+$','_&')
+  let res = s:sub(s:sub(s:findfromview('render\s*(\=\s*\%(:partial\s\+=>\|partial:\)\s*','\1'),'^/',''),'[^/]+$','_&')
   if res != ""|return res."\n".s:findview(res)|endif
 
-  let res = s:findamethod('render\s*:\%(template\|action\)\s\+=>\s*','\1.'.format.'\n\1')
+  let res = s:findamethod('render\>\s*\%(:\%(template\|action\)\s\+=>\|template:\|action:\)\s*','\1.'.format.'\n\1')
   if res != ""|return res|endif
 
   let res = s:sub(s:findfromview('render','\1'),'^/','')
   if buffer.type_name('view') | let res = s:sub(res,'[^/]+$','_&') | endif
   if res != ""|return res."\n".s:findview(res)|endif
 
-  let res = s:findamethod('redirect_to\s*(\=\s*:action\s\+=>\s*','\1')
+  let res = s:findamethod('redirect_to\s*(\=\s*\%\(:action\s\+=>\|\<action:\)\s*','\1')
   if res != ""|return res|endif
 
   let res = s:findfromview('stylesheet_link_tag','public/stylesheets/\1')
@@ -2113,7 +2111,7 @@ function! s:RailsIncludefind(str,...)
     " Classes should always be in .rb files
     let str .= '.rb'
   elseif line =~# ':partial\s*=>\s*'
-    let str = s:sub(str,'([^/]+)$','_\1')
+    let str = s:sub(str,'[^/]+$','_&')
     let str = s:findview(str)
   elseif line =~# '\<layout\s*(\=\s*' || line =~# ':layout\s*=>\s*'
     let str = s:findview(s:sub(str,'^/=','layouts/'))
@@ -3967,111 +3965,6 @@ function! s:BufMappings()
   endif
   " SelectBuf you're a dirty hack
   let v:errmsg = ""
-endfunction
-
-" }}}1
-" Project {{{
-
-function! s:Project(bang,arg)
-  let rr = rails#app().path()
-  exe "Project ".a:arg
-  let line = search('^[^ =]*="'.s:gsub(rr,'[\/]','[\\/]').'"')
-  let projname = s:gsub(fnamemodify(rr,':t'),'\=','-') " .'_on_rails'
-  if line && a:bang
-    let projname = matchstr(getline('.'),'^[^=]*')
-    " Most of this would be unnecessary if the project.vim author had just put
-    " the newlines AFTER each project rather than before.  Ugh.
-    norm zR0"_d%
-    if line('.') > 2
-      delete _
-    endif
-    if line('.') != line('$')
-      .-2
-    endif
-    let line = 0
-  elseif !line
-    $
-  endif
-  if !line
-    if line('.') > 1
-      append
-
-.
-    endif
-    let line = line('.')+1
-    call s:NewProject(projname,rr)
-  endif
-  normal! zMzo
-  if search("^ app=app {","W",line+10)
-    normal! zo
-    exe line
-  endif
-  normal! 0zt
-endfunction
-
-function! s:NewProject(proj,rr)
-    let line = line('.')+1
-    let template = s:NewProjectTemplate(a:proj,a:rr)
-    silent put =template
-    exe line
-    " Ugh. how else can I force detecting folds?
-    setlocal foldmethod=manual
-    norm! $%
-    silent exe "doautocmd User ".s:escarg(a:rr)."/Rproject"
-    let newline = line('.')
-    exe line
-    norm! $%
-    if line('.') != newline
-      call s:warn("Warning: Rproject autocommand failed to leave cursor at end of project")
-    endif
-    exe line
-    setlocal foldmethod=marker
-    setlocal nomodified
-    " FIXME: make undo stop here
-    if !exists("g:maplocalleader")
-      silent! normal \R
-    else " Needs to be tested
-      exe 'silent! normal '.g:maplocalleader.'R'
-    endif
-endfunction
-
-function! s:NewProjectTemplate(proj,rr)
-  let str = a:proj.'="'.a:rr."\" CD=. filter=\"*\" {\n"
-  let str .= " app=app {\n"
-  for dir in ['apis','controllers','helpers','models','views']
-    let str .= s:addprojectdir(a:rr,'app',dir)
-  endfor
-  let str .= " }\n"
-  let str .= " config=config {\n  environments=environments {\n  }\n }\n"
-  let str .= " db=db {\n"
-  let str .= s:addprojectdir(a:rr,'db','migrate')
-  let str .= " }\n"
-  let str .= " lib=lib filter=\"* */**/*.rb \" {\n  tasks=tasks filter=\"**/*.rake\" {\n  }\n }\n"
-  let str .= " public=public {\n  images=images {\n  }\n  javascripts=javascripts {\n  }\n  stylesheets=stylesheets {\n  }\n }\n"
-  if isdirectory(a:rr.'/spec')
-    let str .= " spec=spec {\n"
-    for dir in ['controllers','fixtures','helpers','models','views']
-      let str .= s:addprojectdir(a:rr,'spec',dir)
-    endfor
-    let str .= " }\n"
-  endif
-  if isdirectory(a:rr.'/test')
-    let str .= " test=test {\n"
-    for dir in ['fixtures','functional','integration','mocks','unit']
-      let str .= s:addprojectdir(a:rr,'test',dir)
-    endfor
-    let str .= " }\n"
-  end
-  let str .= "}\n"
-  return str
-endfunction
-
-function! s:addprojectdir(rr,parentdir,dir)
-  if isdirectory(a:rr.'/'.a:parentdir.'/'.a:dir)
-    return '  '.a:dir.'='.a:dir." filter=\"**\" {\n  }\n"
-  else
-    return ''
-  endif
 endfunction
 
 " }}}1

--- a/doc/rails.txt
+++ b/doc/rails.txt
@@ -77,10 +77,10 @@ Rails application development.
    |:Rinvert| takes a self.up migration and writes a self.down.
    |rails-refactoring|
 
-8. Integration with other plugins.  |:Rtree| spawns NERDTree.vim or creates a
-   new project.vim project.  If dbext.vim is installed, it will be
-   transparently configured to reflect database.yml.  Cream users get some
-   additional mappings, and all GUI users get a menu. |rails-integration|
+8. Integration with other plugins.  |:Rtree| spawns NERDTree.vim.  If
+   dbext.vim is installed, it will be transparently configured to reflect
+   database.yml.  Cream users get some additional mappings, and all GUI users
+   get a menu. |rails-integration|
 
 INSTALLATION AND USAGE				*rails-installation*
 
@@ -700,14 +700,9 @@ A handful of Vim plugins are enhanced by rails.vim.  All plugins mentioned can
 be found at http://www.vim.org/.  Cream and GUI menus (for lack of a better
 place) are also covered in this section.
 
-					*rails-:Rtree* *rails-:Rproject*
+						*rails-:Rtree*
 :Rtree [{arg}]		If |NERDTree| is installed, open a tree for the
 			application root or the given subdirectory.
-			Otherwise, if the |project| plugin is installed,
-			invoke :Project (typically without an argument), and
-			search for the root of the current Rails application.
-			If it is not found, create a new project, with
-			appropriate directories (app, etc., but not vendor).
 
 						*rails-:Rdbext* *rails-dbext*
 :Rdbext [{environment}] This command is only provided when the |dbext| plugin


### PR DESCRIPTION
Hi Tim,

I replaced hardcoded paths to stylesheets and scripts, like `public/stylesheets/sass`, with some fancy path detection. 

The detection depends on the corresponding gem being declared in `Gemfile`/`environment.rb`, then proceeds to look for files in a list of possible directories (like `app/stylesheets`, which seems pretty popular), then falls back to retrieving the path from the app itself (slow but sure, and only in rare cases).

Works with Sass, Less, and Coffeescript; I only tested it on Sass since that's what was available.

It's my first experience with vimscript - I tried to be nice. :)

Leonid.
