### PR TITLE
Removed indentation settings because they cannot be overridden by autocmds

### DIFF
--- a/autoload/rails.vim
+++ b/autoload/rails.vim
@@ -4549,9 +4549,6 @@ function! s:BufSettings()
   call self.setvar('&suffixesadd', ".rb,.".s:gsub(s:view_types,',',',.').",.css,.js,.yml,.csv,.rake,.sql,.html,.xml")
   let ft = self.getvar('&filetype')
   if ft =~ '^\%(e\=ruby\|[yh]aml\|javascript\|css\|s[ac]ss\|lesscss\)$'
-    call self.setvar('&shiftwidth',2)
-    call self.setvar('&softtabstop',2)
-    call self.setvar('&expandtab',1)
     if exists('+completefunc') && self.getvar('&completefunc') == ''
       call self.setvar('&completefunc','syntaxcomplete#Complete')
     endif


### PR DESCRIPTION
I have removed the indentation settings because I could not find a sane way to override them with autocmds.
2 Spaces is the defacto standard for ruby, it isn't for javascript so I need to be able to adjust it.
Maybe there is a nicer way to make this customizable though.  :)
