### PR TITLE
add support for rename_index() calls in :Rinvert

### DIFF
--- a/autoload/rails.vim
+++ b/autoload/rails.vim
@@ -3353,8 +3353,8 @@ function! s:invertrange(beg,end)
       let add .= s:mkeep(line)
     elseif line =~ '\<remove_index\>'
       let add = s:sub(s:sub(line,'<remove_index','add_index'),':column\s*=>\s*','')
-    elseif line =~ '\<rename_\%(table\|column\)\>'
-      let add = s:sub(line,'<rename_%(table\s*\(=\s*|column\s*\(=\s*[^,]*,\s*)\zs([^,]*)(,\s*)([^,]*)','\3\2\1')
+    elseif line =~ '\<rename_\%(table\|column\|index\)\>'
+      let add = s:sub(line,'<rename_%(table\s*\(=\s*|%(column|index)\s*\(=\s*[^,]*,\s*)\zs([^,]*)(,\s*)([^,]*)','\3\2\1')
     elseif line =~ '\<change_column\>'
       let add = s:migspc(line).'change_column'.s:mextargs(line,2).s:mkeep(line)
     elseif line =~ '\<change_column_default\>'


### PR DESCRIPTION
This is a fix for [issue 82](https://github.com/tpope/vim-rails/issues/82)
