### PR TITLE
Escape literal "=>" for use with very magic pattern.

### DIFF
--- a/autoload/rails.vim
+++ b/autoload/rails.vim
@@ -3354,7 +3354,7 @@ function! s:invertrange(beg,end)
       endif
       let add .= s:mkeep(line)
     elseif line =~ '\<remove_index\>'
-      let add = s:sub(s:sub(line,'<remove_index','add_index'),':column\s*=>\s*','')
+      let add = s:sub(s:sub(line,'<remove_index','add_index'),':column\s*\=\>\s*','')
     elseif line =~ '\<rename_\%(table\|column\|index\)\>'
       let add = s:sub(line,'<rename_%(table\s*\(=\s*|%(column|index)\s*\(=\s*[^,]*,\s*)\zs([^,]*)(,\s*)([^,]*)','\3\2\1')
     elseif line =~ '\<change_column\>'


### PR DESCRIPTION
Using :Rinvert for this

``` ruby
def self.up
  remove_index 'these', :column => 'field1'
end
```

Vim prints this error message

```
Error detected while processing function <SNR>68_Invert..<SNR>68_invertrange..<SNR>68_sub:
line 1:
E62: Nested =
```

And Rinvert generates this

``` ruby
def self.down
  add_index 'these', :column => 'field1'
end
```

Turns out the error message and the failure to remove `:column =>` are related.  Enjoy.
