### PR TITLE
Always open Rails log on top of the window.

### DIFF
--- a/autoload/rails.vim
+++ b/autoload/rails.vim
@@ -991,7 +991,7 @@ function! s:Log(bang,arg)
     if exists(":Tail")
       Tail  `=rails#app().path(lf)`
     else
-      pedit `=rails#app().path(lf)`
+      top pedit `=rails#app().path(lf)`
     endif
   endif
 endfunction


### PR DESCRIPTION
When vsplit and split are used actively Rlog opens his preview buffer on top of current buffer, that could have small size. SQL queries there are too long to be readable.

http://img7.imagebanana.com/img/ufks08ev/Workspace2_019.png

In order to always have a good vision I think It's a good idea to always open log on top of all buffers.
