### PR TITLE
Fixes for dbext support when using Oracle

### DIFF
--- a/autoload/rails.vim
+++ b/autoload/rails.vim
@@ -3952,7 +3952,7 @@ function! s:app_dbext_settings(environment) dict
       let cmde = '}]; i=0; e=y[e] while e.respond_to?(:to_str) && (i+=1)<16; e.each{|k,v|puts k.to_s+%{=}+v.to_s}}'
       let out = self.lightweight_ruby_eval(cmdb.a:environment.cmde)
       let adapter = s:extractdbvar(out,'adapter')
-      let adapter = get({'mysql2': 'mysql', 'postgresql': 'pgsql', 'sqlite3': 'sqlite', 'sqlserver': 'sqlsrv', 'sybase': 'asa', 'oci': 'ora', 'oracle': 'ora'},adapter,adapter)
+      let adapter = get({'mysql2': 'mysql', 'postgresql': 'pgsql', 'sqlite3': 'sqlite', 'sqlserver': 'sqlsrv', 'sybase': 'asa', 'oracle': 'ora'},adapter,adapter)
       let dict['type'] = toupper(adapter)
       let dict['user'] = s:extractdbvar(out,'username')
       let dict['passwd'] = s:extractdbvar(out,'password')


### PR DESCRIPTION
Tim,

I ran into some issues with the Rdbext command's support for Oracle.

First, the Oracle Rails adaptor is called 'oracle' rather than 'oci' (this
changed around the time of Rails 2, I think), so dbext's database
type wasn't properly being set to 'ora'.

Also the Oracle adaptor expects all the connection information to be in the 'database' config
value, not separately in host, port, database, etc. This is because
Oracle understands various ways of expressing this info, such as the
EZ connect string (host:port/database), a TNS name,
an LDAP name, etc.  The Rails adaptor justs passes the value of
'database' through to the Oracle client, which sorts all that out.
Similarly, dbext's Oracle support expects this stuff in one place,
the 'srvname' config option.  It doesn't seem to use the value of
'dbname' at all, so the fact that rails.vim still sets it doesn't
cause any harm.

Thanks for all your great Vim plugins.

Mark Roghelia
