### PR TITLE
detect rails files when open new tab or window

### DIFF
--- a/plugin/rails.vim
+++ b/plugin/rails.vim
@@ -124,7 +124,7 @@ endfunction
 
 augroup railsPluginDetect
   autocmd!
-  autocmd BufNewFile,BufRead * call s:Detect(expand("<afile>:p"))
+  autocmd BufWinEnter * call s:Detect(expand("<afile>:p"))
   autocmd VimEnter * if expand("<amatch>") == "" && !exists("b:rails_root") | call s:Detect(getcwd()) | endif | if exists("b:rails_root") | silent doau User BufEnterRails | endif
   autocmd FileType netrw if !exists("b:rails_root") | call s:Detect(expand("<afile>:p")) | endif | if exists("b:rails_root") | silent doau User BufEnterRails | endif
   autocmd BufEnter * if exists("b:rails_root")|silent doau User BufEnterRails|endif


### PR DESCRIPTION
I use :tabnew and new windows often. With this fix new buffer will be with rails support automatically.
