### PR TITLE
I fixed a problem, ':Rails new' command.

### DIFF
--- a/autoload/rails.vim
+++ b/autoload/rails.vim
@@ -608,7 +608,7 @@ endfunction
 
 function! s:buffer_name() dict abort
   let app = self.app()
-  let f = s:gsub(fnamemodify(bufname(self.number()),':p'),'\\ @!','/')
+  let f = s:gsub(resolve(fnamemodify(bufname(self.number()),':p')),'\\ @!','/')
   let f = s:sub(f,'/$','')
   let sep = matchstr(f,'^[^\\/]\{3,\}\zs[\\/]')
   if sep != ""


### PR DESCRIPTION
Hi Tim

I'm tacahiroy, one of rails.vim user.
Thank you for the very useful script rails.vim.

[ENVIRONMENT]
OS: OSX Lion(10.7.1)
Vim: MacVim 7.3.273 or Vim 7.3
vim-rails: v4.4(via Vundle)

Today, I encountered following messages when I executed ':Rails new' command.

[MESSAGES]
"~/Projects/rails/sample_app5/README" 261L, 9208C
File /Users/tacahiroy/Projects/rails/sample_app5/README does not appear 
to be under the Rails root /Volumes/HGST500G/Users/tacahiroy/proj/rails/sample_app5.
Please report to the rails.vim author!

/Users/tacahiroy/Projects is a symlink.

``` shell
% ls -ld ~/Projects
lrwxr-xr-x  1 tacahiroy  staff  38  9  7 23:39
/Users/tacahiroy/Projects@ -> /Volumes/HGST500G/Users/tacahiroy/proj
```

Probably, following judgment of path is false
autoload/rails.vim(617L):

``` VimL
if s:startswith(tolower(f),s:gsub(tolower(app.path()),'\\ @!','/')) || f == ""
```

In the case, variable 'f' points symbolic link,
but 'app.path()' returns real path(symlink was resolved).

So, I wrote tiny patch of this problem.
Maybe, it's working good on the other platform.
Is this not good solution?

Thank you.
I'm sorry, my English is very poor X-)
