### PR TITLE
Add SASS syntax highlighting for asset pipeline helper methods

### DIFF
--- a/autoload/rails.vim
+++ b/autoload/rails.vim
@@ -3699,6 +3699,9 @@ function! s:BufSyntax()
       set isk+=$
       exe "syn keyword javascriptRailsFunction ".s:javascript_functions
 
+    elseif &syntax == "scss" || &syntax == "sass"
+      syn match sassFunction "\<\%(\%(asset\|image\|font\|video\|audio\|javascript\|stylesheet\)-\%(url\|path\)\)\>(\@=" contained
+      syn match sassFunction "\<\asset-data-url\>(\@=" contained
     endif
   endif
   call s:HiDefaults()
@@ -4536,7 +4539,7 @@ augroup railsPluginAuto
   autocmd BufWritePost */tasks/**.rake            call rails#cache_clear("rake_tasks")
   autocmd BufWritePost */generators/**            call rails#cache_clear("generators")
   autocmd FileType * if exists("b:rails_root") | call s:BufSettings() | endif
-  autocmd Syntax ruby,eruby,yaml,haml,javascript,coffee,railslog if exists("b:rails_root") | call s:BufSyntax() | endif
+  autocmd Syntax ruby,eruby,yaml,haml,javascript,coffee,railslog,sass,scss if exists("b:rails_root") | call s:BufSyntax() | endif
   autocmd QuickFixCmdPre  *make* call s:push_chdir()
   autocmd QuickFixCmdPost *make* call s:pop_command()
 augroup END


### PR DESCRIPTION
From https://github.com/tpope/vim-haml/pull/24, to add syntax highlighting support for Rails 3.1 helper methods like image-url("foo.png"). 
