### PR TITLE
update abbreviations to use Ruby 1.9 hash syntax

### DIFF
--- a/autoload/rails.vim
+++ b/autoload/rails.vim
@@ -4021,15 +4021,15 @@ function! s:BufAbbreviations()
       Rabbrev coo[ cookies
       Rabbrev fl[ flash
       Rabbrev rr( render
-      Rabbrev ra( render :action\ =>\ 
-      Rabbrev rc( render :controller\ =>\ 
-      Rabbrev rf( render :file\ =>\ 
-      Rabbrev ri( render :inline\ =>\ 
-      Rabbrev rj( render :json\ =>\ 
-      Rabbrev rl( render :layout\ =>\ 
-      Rabbrev rp( render :partial\ =>\ 
-      Rabbrev rt( render :text\ =>\ 
-      Rabbrev rx( render :xml\ =>\ 
+      Rabbrev ra( render action:\ 
+      Rabbrev rc( render controller:\ 
+      Rabbrev rf( render file:\ 
+      Rabbrev ri( render inline:\ 
+      Rabbrev rj( render json:\ 
+      Rabbrev rl( render layout:\ 
+      Rabbrev rp( render partial:\ 
+      Rabbrev rt( render text:\ 
+      Rabbrev rx( render xml:\ 
     endif
     if buffer.type_name('view','helper')
       Rabbrev dotiw distance_of_time_in_words
@@ -4037,8 +4037,8 @@ function! s:BufAbbreviations()
     endif
     if buffer.type_name('controller')
       Rabbrev re(  redirect_to
-      Rabbrev rea( redirect_to :action\ =>\ 
-      Rabbrev rec( redirect_to :controller\ =>\ 
+      Rabbrev rea( redirect_to action:\ 
+      Rabbrev rec( redirect_to controller:\ 
       Rabbrev rst( respond_to
     endif
     if buffer.type_name() ==# 'model' || buffer.type_name('model-arb')
@@ -4076,13 +4076,13 @@ function! s:BufAbbreviations()
       Rabbrev asre( assert_response
       Rabbrev art(  assert_redirected_to
     endif
-    Rabbrev :a    :action\ =>\ 
+    Rabbrev :a    action:\ 
     " hax
-    Rabbrev :c    :co________\ =>\ 
+    Rabbrev :c    co________:\ 
     inoreabbrev <buffer> <silent> :c <C-R>=<SID>TheCWord()<CR>
-    Rabbrev :i    :id\ =>\ 
-    Rabbrev :o    :object\ =>\ 
-    Rabbrev :p    :partial\ =>\ 
+    Rabbrev :i    id:\ 
+    Rabbrev :o    object:\ 
+    Rabbrev :p    partial:\ 
     Rabbrev logd( logger.debug
     Rabbrev logi( logger.info
     Rabbrev logw( logger.warn


### PR DESCRIPTION
Don't know if you'll want to merge this or not.  Maybe keep it in a separate
ruby19 branch since Ruby 1.8 hash syntax will live on forever in legacy
systems. :(

Cheers.
