### PR TITLE
Add xdg-open support to OpenURL

### DIFF
--- a/autoload/rails.vim
+++ b/autoload/rails.vim
@@ -1334,6 +1334,8 @@ function! s:initOpenURL()
       command -bar -nargs=1 OpenURL :!open <args>
     elseif has("gui_win32")
       command -bar -nargs=1 OpenURL :!start cmd /cstart /b <args>
+    elseif executable("xdg-open")
+      command -bar -nargs=1 OpenURL :!xdg-open <args>
     elseif executable("sensible-browser")
       command -bar -nargs=1 OpenURL :!sensible-browser <args>
     elseif executable('launchy')


### PR DESCRIPTION
- This is mostly standard on Linux-based desktop environments and
  respects users' browser settings in their desktop environment, unlike
  sensible-browser; but still allow falling back to sensible-browser
- Using sh -c was the only thing I tried that worked; it seems like
  "-open" is getting interpreted specially by vim for some reason.
