### PR TITLE
Drop init of rails_statusline option

### DIFF
--- a/plugin/rails.vim
+++ b/plugin/rails.vim
@@ -51,7 +51,6 @@ function! s:SetOptDefault(opt,val)
   endif
 endfunction
 
-call s:SetOptDefault("rails_statusline",1)
 call s:SetOptDefault("rails_syntax",1)
 call s:SetOptDefault("rails_mappings",1)
 call s:SetOptDefault("rails_abbreviations",1)


### PR DESCRIPTION
Statusline support has been removed in d10c6e7 and therefore the
rails_statusline option is obsolete.
