### PR TITLE
Complete closer-matching partial file names before views

### DIFF
--- a/autoload/rails.vim
+++ b/autoload/rails.vim
@@ -2183,6 +2183,9 @@ function! s:completion_filter(results,A)
   call filter(results,'v:val !~# "\\~$"')
   let filtered = filter(copy(results),'s:startswith(v:val,a:A)')
   if !empty(filtered) | return filtered | endif
+  let prefix = s:sub(a:A,'(.*[/]|^)','&_')
+  let filtered = filter(copy(results),"s:startswith(v:val,prefix)")
+  if !empty(filtered) | return filtered | endif
   let regex = s:gsub(a:A,'[^/]','[&].*')
   let filtered = filter(copy(results),'v:val =~# "^".regex')
   if !empty(filtered) | return filtered | endif


### PR DESCRIPTION
Makes 'foo' complete '_foo.html.erb' instead of 'fxoo.html.erb',
but 'f' still prefers 'fxoo' over '_foo'.

Closes #183
