### PR TITLE
Complete closer-matching partial file names before views

### DIFF
--- a/autoload/rails.vim
+++ b/autoload/rails.vim
@@ -2183,7 +2183,7 @@ function! s:completion_filter(results,A)
   call filter(results,'v:val !~# "\\~$"')
   let filtered = filter(copy(results),'s:startswith(v:val,a:A)')
   if !empty(filtered) | return filtered | endif
-  let regex = s:gsub(a:A,'[^/]','[&].*')
+  let regex = s:gsub(s:gsub(a:A,'[^/]','[&].*'),'(.*[/]|^)','&_?')
   let filtered = filter(copy(results),'v:val =~# "^".regex')
   if !empty(filtered) | return filtered | endif
   let regex = s:gsub(a:A,'.','[&].*')


### PR DESCRIPTION
Makes 'foo' complete '_foo.html.erb' instead of 'fxoo.html.erb',
but 'f' still prefers 'fxoo' over '_foo'.

Alternate solution for #183
