### PR TITLE
Support spec/features for integration tests

### DIFF
--- a/autoload/rails.vim
+++ b/autoload/rails.vim
@@ -1615,6 +1615,7 @@ function! s:Complete_script(ArgLead,CmdLine,P)
     elseif target ==# 'integration_test' || target ==# 'integration_spec' || target ==# 'feature'
       return s:autocamelize(
             \ rails#app().relglob('test/integration/','**/*','_test.rb') +
+            \ rails#app().relglob('spec/features/', '**/*', '_spec.rb') +
             \ rails#app().relglob('spec/requests/', '**/*', '_spec.rb') +
             \ rails#app().relglob('features/', '**/*', '.feature'), a:ArgLead)
     elseif target ==# 'metal'
@@ -2170,6 +2171,7 @@ function! s:BufFinderCommands()
         \ ['test', 'test/integration/%s_test.rb'],
         \ ['spec', 'spec/requests/%s_spec.rb'],
         \ ['spec', 'spec/integration/%s_spec.rb'],
+        \ ['spec', 'spec/features/%s_spec.rb'],
         \ ['cucumber', 'features/%s.feature'],
         \ ['turnip', 'spec/acceptance/%s.feature']],
         \ 'rails#app().has(v:val[0])'), 'v:val[1]')
@@ -2180,6 +2182,7 @@ function! s:BufFinderCommands()
           \   'test/integration/': "require 'test_helper'\n\nclass %STest < ActionDispatch::IntegrationTest\nend",
           \   'spec/requests/': "require 'spec_helper'\n\ndescribe \"%h\" do\nend",
           \   'spec/integration/': "require 'spec_helper'\n\ndescribe \"%h\" do\nend",
+          \   'spec/features/': "require 'spec_helper'\n\ndescribe \"%h\" do\nend",
           \   'features/': "Feature: %h",
           \   'spec/acceptance': "Feature: %h"},
           \ 'default': [
@@ -4413,7 +4416,7 @@ function! s:SetBasePath()
     let path += ['test', 'test/unit', 'test/functional', 'test/integration', 'test/controllers', 'test/helpers', 'test/mailers', 'test/models']
   endif
   if self.app().has('spec')
-    let path += ['spec', 'spec/controllers', 'spec/helpers', 'spec/mailers', 'spec/models', 'spec/views', 'spec/lib', 'spec/requests', 'spec/integration']
+    let path += ['spec', 'spec/controllers', 'spec/helpers', 'spec/mailers', 'spec/models', 'spec/views', 'spec/lib', 'spec/requests', 'spec/integration', 'spec/features']
   endif
   let path += ['vendor/plugins/*/lib', 'vendor/plugins/*/test', 'vendor/rails/*/lib', 'vendor/rails/*/test']
   call map(path,'self.app().path(v:val)')


### PR DESCRIPTION
With the advent of Capybara 2, the community [decided that RSpec needed
yet another name for integration tests](http://alindeman.github.com/2012/11/11/rspec-rails-and-capybara-2.0-what-you-need-to-know.html). My `:Rintegrationtest` muscle memory was killing me.
