### PR TITLE
Fix typo in :Rake command

### DIFF
--- a/autoload/rails.vim
+++ b/autoload/rails.vim
@@ -1347,7 +1347,7 @@ function! s:readable_default_rake_task(...) dict abort
       if test =~# '^test/unit\>'
         return 'test:units TEST='.s:rquote(test).opts
       elseif test =~# '^test/functional\>'
-        return 'test:functional TEST='.s:rquote(test).opts
+        return 'test:functionals TEST='.s:rquote(test).opts
       elseif test =~# '^test/integration\>'
         return 'test:integration TEST='.s:rquote(test).opts
       elseif test ==# 'test'


### PR DESCRIPTION
When you run :Rake in a functional test it fails because of a missing s (It builds rake test:functional instead of rake test:functionals)

Cheers.
