### PR TITLE
Allow Capybara-style integration specs

### DIFF
--- a/autoload/rails.vim
+++ b/autoload/rails.vim
@@ -1273,7 +1273,7 @@ function! s:readable_test_file_candidates() dict abort
           \ '<test/mailers/', 'test/functional/'),
           \ '<test/controllers/', 'test/functional/')
     let tests = s:uniq([test_file, old_test_file, spec_file])
-  elseif f =~# '\<\(test\|spec\)/\%(\1_helper\.rb$\|support\>\)' || f =~# '\<features/.*\.rb$'
+  elseif f =~# '\<\(test\|spec\)/\%(\1_helper\.rb$\|support\>\)' || (f =~# '\<features/.*\.rb$' && !self.type_name('spec'))
     let tests = [matchstr(f, '.*\<\%(test\|spec\|features\)\>')]
   elseif self.type_name('test', 'spec', 'cucumber')
     let tests = [f]


### PR DESCRIPTION
I'm told that newer Capybara integration specs are created in the 'spec/features' directory. The "any ruby file under a directory called features" regex here was too greedy.

I'm sure this fix can be done using negative look-behind, but who's got the time?
