### PR TITLE
Map Rails 4 testing directories to rake tasks

### DIFF
--- a/autoload/rails.vim
+++ b/autoload/rails.vim
@@ -1386,9 +1386,9 @@ function! s:readable_default_rake_task(...) dict abort
           let opts = ' TESTOPTS=-n'.method
         endif
       endif
-      if test =~# '^test/unit\>'
+      if test =~# '^test/\%(unit\|models\)\>'
         return 'test:units TEST='.s:rquote(test).opts
-      elseif test =~# '^test/functional\>'
+      elseif test =~# '^test/\%(functional\|controllers\)\>'
         return 'test:functionals TEST='.s:rquote(test).opts
       elseif test =~# '^test/integration\>'
         return 'test:integration TEST='.s:rquote(test).opts


### PR DESCRIPTION
This adds the Rails 4 idiom of creating test directories named "models" and "controllers" (in lieu of "unit" and "functional") to the pattern matches when running `:Rake`:, selecting the appropriate rake task to run.

This allows those doing Rails 4 development to run `:Rake` and avoid falling down to the deprecated `test:recent`.

This is related to Issue #252.
