### PR TITLE
Make Rg and Rgem open Gemfile

### DIFF
--- a/autoload/rails.vim
+++ b/autoload/rails.vim
@@ -2324,6 +2324,10 @@ function! s:app_commands() dict abort
         \ {'pattern': 'config/environments/*.rb'},
         \ {'pattern': 'config/application.rb'},
         \ {'pattern': 'config/environment.rb'}]
+  let commands.g  = [
+        \ {'pattern': 'Gemfile'}]
+  let commands.gem  = [
+        \ {'pattern': 'Gemfile'}]
   let commands.helper = [{
         \ 'pattern': 'app/helpers/*_helper.rb',
         \ 'template': "module %SHelper\nend",


### PR DESCRIPTION
Right now to get the the Gemfile you can either do Rlib (with no parameters) or R Gemfile. 

This is okay, but I'd prefer to have a shortcut for this, something like Rgem and/or Rg. Rlib is short, but it's not named properly.

I know it's a small thing, but it bothers me because I go to the Gemfile a lot. It would be nice to have a shortcut. 

What do you think? 
