### PR TITLE
Recognize Capistrano v3 .cap files as task

### DIFF
--- a/autoload/rails.vim
+++ b/autoload/rails.vim
@@ -780,7 +780,7 @@ function! s:readable_calculate_file_type() dict abort
     let r = "db-migration"
   elseif f=~ '\<db/schema\.rb$'
     let r = "db-schema"
-  elseif f =~ '\.rake$' || f =~ '\<\%(Rake\|Cap\)file$' || f =~ '\<config/deploy\.rb$' || f =~ '\<config/deploy/.*\.rb$'
+  elseif f =~ '\.rake$' || f =~ '\.cap$' || f =~ '\<\%(Rake\|Cap\)file$' || f =~ '\<config/deploy\.rb$' || f =~ '\<config/deploy/.*\.rb$'
     let r = "task"
   elseif f =~ '\<log/.*\.log$'
     let r = "log"


### PR DESCRIPTION
Capistrano v3 creates .cap files in lib/capistrano/tasks/ which are basically rake tasks and should be recognized appropriately.
