### PR TITLE
Improve readable_alternate_candidates for js files

### DIFF
--- a/autoload/rails.vim
+++ b/autoload/rails.vim
@@ -3201,8 +3201,15 @@ function! s:readable_alternate_candidates(...) dict abort
     return [migration . (exists('lastmethod') && !empty(lastmethod) ? '#'.lastmethod : '')]
   elseif f =~# '\<application\.js$'
     return ['app/helpers/application_helper.rb']
+  elseif f =~# 'spec\.js$'
+    return [s:sub(s:sub(f, 'spec/javascripts', 'app/assets/javascripts'), '_spec.js', '.js')."\n"]
   elseif self.type_name('javascript')
-    return ['app/assets/javascripts/application.js', 'public/javascripts/application.js']
+    if f =~ 'public/javascripts'
+      let to_replace = 'public/javascripts'
+    else
+      let to_replace = 'app/assets/javascripts'
+    endif
+    return [s:sub(s:sub(f, to_replace, 'spec/javascripts'), '.js', '_spec.js')."\n"]
   elseif self.type_name('db-schema') || f =~# '^db/\w\+_structure.sql$'
     return ['db/seeds.rb']
   elseif f ==# 'db/seeds.rb'


### PR DESCRIPTION
Maps between app/assets/javascripts and spec/javascripts so :AV works properly with javascript specs.

Adapted from @rupurt's patch on an older version of this plugin -
https://github.com/Casecommons/vim-rails/commit/0f6fbd624c2d8c1310d2a79914ad854d9c747e7b

(I emailed him to see if he wanted to submit it upstream himself or if I should just do it, and his response was: "Go ahead and submit it yourself. The most important thing is that you fix the issue!" :heart:)
