### PR TITLE
Support change_column_null

### DIFF
--- a/autoload/rails.vim
+++ b/autoload/rails.vim
@@ -3448,6 +3448,8 @@ function! s:invertrange(beg,end)
       let add = s:migspc(line).'change_column'.s:mextargs(line,2).s:mkeep(line)
     elseif line =~ '\<change_column_default\>'
       let add = s:migspc(line).'change_column_default'.s:mextargs(line,2).s:mkeep(line)
+    elseif line =~ '\<change_column_null\>'
+      let add = s:migspc(line).'change_column_null'.s:mextargs(line,2).s:mkeep(line)
     elseif line =~ '\.update_all(\(["'."'".']\).*\1)$' || line =~ '\.update_all \(["'."'".']\).*\1$'
       " .update_all('a = b') => .update_all('b = a')
       let pre = matchstr(line,'^.*\.update_all[( ][}'."'".'"]')
@@ -3680,7 +3682,7 @@ function! s:BufSyntax()
       endif
       if buffer.type_name('db-migration','db-schema')
         syn keyword rubyRailsMigrationMethod create_table change_table drop_table rename_table create_join_table drop_join_table
-        syn keyword rubyRailsMigrationMethod add_column rename_column change_column change_column_default remove_column remove_columns
+        syn keyword rubyRailsMigrationMethod add_column rename_column change_column change_column_default change_column_null remove_column remove_columns
         syn keyword rubyRailsMigrationMethod add_timestamps remove_timestamps
         syn keyword rubyRailsMigrationMethod add_reference remove_reference add_belongs_to remove_belongs_to
         syn keyword rubyRailsMigrationMethod add_index remove_index rename_index


### PR DESCRIPTION
Add syntax highlighting on `change_column_null` method in migration
files. You can get further detail on it from the API reference:

http://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/SchemaStatements.html#method-i-change_column_null
