### PR TITLE
Don't let Detect() bottom out to checking //

### DIFF
--- a/plugin/rails.vim
+++ b/plugin/rails.vim
@@ -63,6 +63,9 @@ function! s:Detect(filename)
     endif
     let ofn = fn
     let fn = fnamemodify(ofn,':h')
+    if fn == '/'
+      let fn = ''
+    endif
   endwhile
   return 0
 endfunction


### PR DESCRIPTION
NOTE: I'm not a an experienced vim coder so please make this change yourself if adding this hacky if is not the proper way :)

Solves bug for cygwin users where this would cause a network lookup which can be painfully slow in windows.

This is the same bug as: https://github.com/tpope/vim-fugitive/issues/210

On windows if you end up checking a '//...' path for anything windows decides the best course of action is to stall out and check network paths.
