### PR TITLE
Add highlighting for new rspec-mocks syntax

### DIFF
--- a/autoload/rails.vim
+++ b/autoload/rails.vim
@@ -3725,7 +3725,7 @@ function! s:BufSyntax()
       elseif buffer.type_name('spec')
         syn keyword rubyRailsTestMethod describe context it its specify shared_context shared_examples_for it_should_behave_like it_behaves_like before after around subject fixtures controller_name helper_name scenario feature background
         syn match rubyRailsTestMethod '\<let\>!\='
-        syn keyword rubyRailsTestMethod violated pending expect double mock mock_model stub_model
+        syn keyword rubyRailsTestMethod violated pending expect allow double instance_double mock mock_model stub_model
         syn match rubyRailsTestMethod '\.\@<!\<stub\>!\@!'
         if !buffer.type_name('spec-model')
           syn match   rubyRailsTestControllerMethod  '\.\@<!\<\%(get\|post\|put\|patch\|delete\|head\|process\|assigns\)\>'


### PR DESCRIPTION
Highlight `allow` and `instance_double` from [rspec-mocks](https://github.com/rspec/rspec-mocks)  in the same manner as `expect` and `double`.
