### PR TITLE
Make helper tests first class citizens

### DIFF
--- a/autoload/rails.vim
+++ b/autoload/rails.vim
@@ -1411,7 +1411,7 @@ function! s:readable_default_rake_task(...) dict abort
       elseif test ==# 'test'
         return 'test'
       else
-        return 'test:recent TEST='.s:rquote(test).opts
+        return 'test:units TEST='.s:rquote(test).opts
       endif
     elseif test =~# '^spec\>'
       return 'spec SPEC='.s:rquote(with_line)


### PR DESCRIPTION
When you run :Rake in a helper rake test:recents TEST=xx is executed instead of rake test:helpers TEST=xx

Cheers.
