### PR TITLE
Shorten the app path if possible

### DIFF
--- a/autoload/rails.vim
+++ b/autoload/rails.vim
@@ -3064,7 +3064,7 @@ function! s:readable_open_command(cmd, argument, name, projections) dict abort
       let file = ''
     endif
     if !empty(file) && self.app().has_path(file)
-      let file = self.app().path(file)
+      let file = fnamemodify(self.app().path(file), ':.')
       return cmd . ' ' . s:fnameescape(file) . '|exe ' . s:sid . 'djump('.string(djump) . ')'
     endif
   endfor
@@ -3104,7 +3104,8 @@ function! s:readable_open_command(cmd, argument, name, projections) dict abort
         let template = s:split(get(projected, 0, ''))
       endif
       call map(template, 's:gsub(v:val, "\t", "  ")')
-      return cmd . ' ' . s:fnameescape(simplify(file)) . '|call setline(1, '.string(template).')' . '|set nomod'
+      let file = fnamemodify(simplify(file), ':.')
+      return cmd . ' ' . s:fnameescape(file) . '|call setline(1, '.string(template).')' . '|set nomod'
     endif
   endfor
   return 'echoerr '.string("Couldn't find destination directory for ".a:name.' '.a:argument)


### PR DESCRIPTION
When I open a file with, for example, `:Emodel user`, the plugin always opens the absolute path, instead of the relative one. Adding a simple `fnamemodify` changes this.

I'm actually surprised this happens, since, if I just `edit` the absolute path myself, it's nicely shortened. Not sure why this happens. Incidentally, I also found [this function here](https://github.com/tpope/vim-rails/blob/0bb6d900af43c0fc274980ec2a8037b1f7dfdd7a/autoload/rails.vim#L3153), so maybe that's the one that should be used in `s:readable_open_command`? Or maybe the path should be relativized there?
