### PR TITLE
adds flexibility to views location

### DIFF
--- a/autoload/rails.vim
+++ b/autoload/rails.vim
@@ -999,7 +999,7 @@ function! s:BufCommands()
     command! -buffer -bar -nargs=? -complete=customlist,s:Complete_environments Rdbext  :call s:BufDatabase(2,<q-args>)|let b:dbext_buffer_defaulted = 1
   endif
   let ext = expand("%:e")
-  if RailsFilePath() =~ '\<app/views/'
+  if RailsFilePath() =~ '\<app/\(.*\/\)\?views/'
     " TODO: complete controller names with trailing slashes here
     command! -buffer -bar -bang -nargs=? -range -complete=customlist,s:controllerList Rextract :<line1>,<line2>call s:Extract(<bang>0,<f-args>)
     command! -buffer -bar -bang -nargs=? -range -complete=customlist,s:controllerList Extract  :<line1>,<line2>call s:Extract(<bang>0,<f-args>)


### PR DESCRIPTION
This PR adds the possibility of using the extract functions inside views that aren't in the "app/views" directory, but are still following the Rails conventions (e.g "app/themes/base/views").

From the tests made, everything seems ok. 
