### PR TITLE
Adds `skip` as a keyword for syntax highlighting

### DIFF
--- a/autoload/rails.vim
+++ b/autoload/rails.vim
@@ -3804,7 +3804,7 @@ function! rails#buffer_syntax()
       elseif buffer.type_name('spec')
         syn keyword rubyRailsTestMethod describe context it its specify shared_context shared_examples shared_examples_for shared_context include_examples include_context it_should_behave_like it_behaves_like before after around subject fixtures controller_name helper_name scenario feature background
         syn match rubyRailsTestMethod '\<let\>!\='
-        syn keyword rubyRailsTestMethod violated pending expect allow double instance_double mock mock_model stub_model
+        syn keyword rubyRailsTestMethod violated pending expect allow double instance_double mock mock_model stub_model skip
         syn match rubyRailsTestMethod '\.\@<!\<stub\>!\@!'
         if !buffer.type_name('spec-model')
           syn match   rubyRailsTestControllerMethod  '\.\@<!\<\%(get\|post\|put\|patch\|delete\|head\|process\|assigns\)\>'


### PR DESCRIPTION
Adds rspec's `skip` method to the syntax highlighting list.