### PR TITLE
Support rails_helper.rb from rspec 3

### DIFF
--- a/autoload/rails.vim
+++ b/autoload/rails.vim
@@ -2978,6 +2978,7 @@ function! s:specEdit(cmd,...) abort
   let describe = s:sub(s:sub(rails#camelize(a:0 ? a:1 : ''), '^[^:]*::', ''), '!.*', '')
   return rails#buffer().open_command(a:cmd, a:0 ? a:1 : '', 'spec', [
         \ {'pattern': 'spec/*_spec.rb', 'template': "require 'spec_helper'\n\ndescribe ".describe." do\nend"},
+        \ {'pattern': 'spec/rails_helper.rb'},
         \ {'pattern': 'spec/spec_helper.rb'}])
 endfunction
 


### PR DESCRIPTION
I use rspec 3 and the opening of spec_helper.rb instead of rails_helper.rb was not helpful. After this commit it now opens rails_helper.rb with a fallback to spec_helper.rb. Do you feel this would be a good fit for your plugin?