### PR TITLE
fix a typo bug for var name

### DIFF
--- a/autoload/rails.vim
+++ b/autoload/rails.vim
@@ -2253,7 +2253,7 @@ function! s:RailsFind()
   let ssext = ['css', 'css.*', 'scss', 'sass']
   let res = s:findfromview('stylesheet[_-]\%(link_tag\|path\|url\)\|\%(path\|url\)_to_stylesheet','\1')
   if res != ""
-    return rails#app().resolve_asset(res, ssest)."\npublic/stylesheets/".res.".css"
+    return rails#app().resolve_asset(res, ssext)."\npublic/stylesheets/".res.".css"
   endif
   if buffer.type_name('stylesheet')
     let res = s:findit('^\s*\*=\s*require\s*["'']\=\([^"'' ]*\)', '\1')


### PR DESCRIPTION
Was getting an error when hitting `gf` to jump to a stylesheet.

![error](https://cloud.githubusercontent.com/assets/1671/7608289/fe2faf06-f95f-11e4-9212-9b97ecb424e4.png)
