### PR TITLE
Disabling/improving RailsFind in javascript files?

### DIFF
--- a/autoload/rails.vim
+++ b/autoload/rails.vim
@@ -2182,6 +2182,7 @@ function! s:RailsFind()
   if buffer.type_name('javascript')
     let res = s:findit('^\s*//=\s*require\s*["'']\=\([^"'' ]*\)', '\1')
     if res != ""|return rails#app().resolve_asset(res, jsext)."\napp/assets/javascripts/".res.".js"|endif
+    return expand("<cfile>")
   endif
 
   let res = s:findit('\v\s*<require\s*\(=\s*File.dirname\(__FILE__\)\s*\+\s*[:'."'".'"](\f+)>.=',expand('%:h').'/\1')


### PR DESCRIPTION
Hi there - I'm struggling with RailsFind in javascript files.

If have a vimrc that just loads vim-rails, and tweaks suffixes for javascript files : 

```vim
set nocompatible
filetype off " force reloading of filetype
set rtp+=~/.vim/bundle/vundle/
call vundle#begin()
Bundle 'tpope/vim-rails'
call vundle#end()

autocmd FileType javascript set suffixesadd=.js
```

and I try to use `gf` on this : 

```js
require('utilities/images')
```

then vim warns me `E345: Can't find file "utilities/images.rb" in path`.

If I disable vim-rails, or map RailsFind to something else, then it successfully opens `utilities/images.js`.

Any suggestions on either disabling RailsFind in my javascript, or making it smarter about opening my javascript modules?