### PR TITLE
Launch xdg-open in the background

### DIFF
--- a/autoload/rails.vim
+++ b/autoload/rails.vim
@@ -1459,7 +1459,7 @@ function! s:initOpenURL() abort
     elseif has("gui_win32")
       command -bar -nargs=1 OpenURL :!start cmd /cstart /b <args>
     elseif executable("xdg-open")
-      command -bar -nargs=1 OpenURL :!xdg-open <args>
+      command -bar -nargs=1 OpenURL :!xdg-open <args> &
     elseif executable("sensible-browser")
       command -bar -nargs=1 OpenURL :!sensible-browser <args>
     elseif executable('launchy')


### PR DESCRIPTION
Fixes #172. Works around not working inside GVim.