### PR TITLE
Convert all default templates to array format

### DIFF
--- a/autoload/rails.vim
+++ b/autoload/rails.vim
@@ -4520,17 +4520,23 @@ let s:default_projections = {
       \    "type": "helper"
       \  },
       \  "app/jobs/*_job.rb": {
-      \    "template": "class {camelcase|capitalize|colons}Job < ActiveJob::Base\nend",
+      \    "template": [
+      \      "class {camelcase|capitalize|colons}Job < ActiveJob::Base",
+      \      "end"
+      \    ],
       \    "type": "job"
       \  },
       \  "app/mailers/*.rb": {
       \    "affinity": "controller",
-      \    "template": "class {camelcase|capitalize|colons} < ActionMailer::Base\nend",
+      \    "template": [
+      \      "class {camelcase|capitalize|colons} < ActionMailer::Base",
+      \      "end"
+      \    ],
       \    "type": "mailer"
       \  },
       \  "app/models/*.rb": {
       \    "affinity": "model",
-      \    "template": "class %S\nend",
+      \    "template": ["class %S", "end"],
       \    "type": "model"
       \  },
       \  "config/application.rb": {"alternate": "config/routes.rb"},


### PR DESCRIPTION
This fixes #418.

`s:extend_projection` assumes `template` is in array format, so it crashes when it tries to extend a projection with `template` in string format.