### PR TITLE
Add lib to default projections

### DIFF
--- a/autoload/rails.vim
+++ b/autoload/rails.vim
@@ -4545,6 +4545,7 @@ let s:default_projections = {
       \    "type": "initializer"
       \  },
       \  "gems.rb": {"alternate": "gems.locked", "type": "lib"},
+      \  "lib/*.rb": {"type": "lib"},
       \  "lib/tasks/*.rake": {"type": "task"}
       \}
 


### PR DESCRIPTION
It looks like https://github.com/tpope/vim-rails/commit/457006c2a16e9451b4f1e7d1201275b93f02cf47 accidentally removed `lib` from the default projections.