### PR TITLE
Add alternate support for camel case javascript naming

### DIFF
--- a/autoload/rails.vim
+++ b/autoload/rails.vim
@@ -3338,6 +3338,8 @@ function! s:readable_alternate_candidates(...) dict abort
     return ['app/helpers/application_helper.rb']
   elseif f =~# 'spec\.js$'
     return [s:sub(s:sub(f, 'spec/javascripts', 'app/assets/javascripts'), '_spec.js', '.js')]
+  elseif f =~# 'Spec\.js$'
+    return [s:sub(s:sub(f, 'spec/javascripts', 'app/assets/javascripts'), 'Spec.js', '.js')]
   elseif f =~# 'spec\.coffee$'
     return [s:sub(s:sub(f, 'spec/javascripts', 'app/assets/javascripts'), '_spec.coffee', '.coffee')]
   elseif f =~# 'spec\.js\.coffee$'
@@ -3354,6 +3356,9 @@ function! s:readable_alternate_candidates(...) dict abort
     elseif f =~ '.coffee$'
       let suffix = '.coffee'
       let suffix_replacement = '_spec.coffee'
+    elseif f =~ '[A-Z][a-z]\+\.js$'
+      let suffix = '.js'
+      let suffix_replacement = 'Spec.js'
     else
       let suffix = '.js'
       let suffix_replacement = '_spec.js'


### PR DESCRIPTION
Hi,

This is a patch that allow :A command to support Rails application with camel case naming on javascript, for example, 'app/assets/javascripts/SomeComponent.js' can map to 'spec/javascripts/SomeComponentSpec.js' since camel case is javascript standard.

Also this will not effect the snake case mapping.