### PR TITLE
Adjust the timezone offset on the other bound

### DIFF
--- a/autoload/rails.vim
+++ b/autoload/rails.vim
@@ -2789,6 +2789,8 @@ function! s:migrationEdit(cmd,...)
     let offset = local - ts % 86400
     if offset <= -12 * 60 * 60
       let offset += 86400
+    elseif offset >= 12 * 60 * 60
+      let offset -= 86400
     endif
     let template = 'class ' . rails#camelize(matchstr(arg, '[^!]*')) . " < ActiveRecord::Migration\nend"
     return rails#buffer().open_command(a:cmd, strftime('%Y%m%d%H%M%S', ts - offset).'_'.arg, 'migration',


### PR DESCRIPTION
At certain times of day (based on a person's UTC offset) the migration
timestamp generated by `:Emigration CreateATable!` can end up being 24
hours earlier than what it is supposed to be.

For instance, when I created a migration on March 31st at 2pm, the
following timestamp is created:

20160331190000 (2016-03-31 19:00:00)

Later that day at 8:30pm, I created another migration and the following
timestamp was created:

20160331013000 (2016-03-31 01:30:00)

The timestamp I was expecting is:

20160401013000 (2016-04-01 01:30:00)

Obviously this is problematic because it means that at certain times of
the day migrations are being created with timestamps that place them out
of order.

I am in central timezone, so my UTC offset is -5. I noticed that after
7pm (which in UTC is after midnight, so the next day), the timestamps
generated by the current implementation of migrationEdit are 24 hours
off from what they should be. Part of the timestamp calculation adds 24
hours worth of seconds to the offset when it is less then (-12 * 60 *
60). Similarly, the offset needs to be adjusted by subtracting 24 hours
worth of seconds when the offset is greater than (12 * 60 * 60).