### PR TITLE
Allow setting a custom set of callbacks for gf

### DIFF
--- a/autoload/rails.vim
+++ b/autoload/rails.vim
@@ -2185,6 +2185,22 @@ function! s:cfile(...) abort
   let buffer = rails#buffer()
   let format = s:format()
 
+  if exists('g:rails_gf_callbacks')
+    for callback in g:rails_gf_callbacks
+      if !exists('*'.callback)
+        continue
+      endif
+
+      let saved_view = winsaveview()
+      let res = call(callback, [])
+      call winrestview(saved_view)
+
+      if res != '' && filereadable(res)
+        return res
+      endif
+    endfor
+  endif
+
   let ssext = ['css', 'css.*', 'scss', 'sass']
   if buffer.type_name('stylesheet')
     let res = s:findit('^\s*\*=\s*require\s*["'']\=\([^"'' ]*\)', '\1')


### PR DESCRIPTION
This PR makes the `gf` family of commands look for `g:rails_gf_callbacks` that holds a list of functions. Each of those functions is run in turn, and if any one of them returns a non-empty string that points to an existing file, that's the file we follow.

This changes nothing in the existing API and just allows an extension point for advanced users. I tried setting my own `includeexpr`, but I couldn't really manage to pull it off, and this is the simplest thing I could think of.

For an example of what I would use it for: https://gist.github.com/AndrewRadev/7d678be6b6302793057b5cdcaae35f2b. This snippet won't work as-is (It uses a function from my `ember_tools` plugin), but the short version of what it does is, it looks for `t "some.translation.key"`, and returns `config/locales/en.yml`, while setting up a callback to search for that key when it opens the file, using a series of autocommands. It's a bit weird, but it seems to work surprisingly well so far. Still, not something I'd stick in rails.vim without further testing. Having it implementable externally, though, shouldn't hurt the project.

I'm open to any ideas about variable naming, documentation, and so on. I'm also wondering if the callbacks shouldn't be given any arguments, like the rails root (I return a hardcoded "config/...", since I always keep the rails root as my cwd, but other people might need it). Let me know what you think.