### PR TITLE
Add an option to use single quotes for partials

### DIFF
--- a/autoload/rails.vim
+++ b/autoload/rails.vim
@@ -3443,7 +3443,11 @@ function! s:Extract(bang,...) range abort
     let erub2 = ''
   endif
   let spaces = matchstr(getline(first),"^ *")
-  let renderstr = 'render "'.fnamemodify(file,":r:r").'"'
+  if exists('g:rails_single_quotes_style')
+    let renderstr = "render '".fnamemodify(file,":r:r")."'"
+  else
+    let renderstr = 'render "'.fnamemodify(file,":r:r").'"'
+  endif
   if ext =~? '^\%(rhtml\|erb\|dryml\)$'
     let renderstr = "<%= ".renderstr." %>"
   elseif ext == "rxml" || ext == "builder"

--- a/doc/rails.txt
+++ b/doc/rails.txt
@@ -887,6 +887,10 @@ single project.
 Gem maintainers may also provide custom projections by placing them in
 lib/rails/projections.json.
 
+						*g:rails_single_quotes_style*
+Uses single quotes instead of double quotes when generating partials.  See
+|rails-partials|.
+
 ABOUT					*rails-about* *rails-plugin-author*
 
 The latest stable version can be found at


### PR DESCRIPTION
Add a `g:rails_single_quotes_style` option. Addresses #458 and the discussions in #343.

I am not a Vimscript guru (being a recent Vim convert) but after hacking these lines together, this seems to work.
