### PR TITLE
Change spec default template to require rails_helper instead of spec_helper

### DIFF
--- a/autoload/rails.vim
+++ b/autoload/rails.vim
@@ -3000,8 +3000,9 @@ endfunction
 function! s:specEdit(cmd,...) abort
   let describe = s:sub(s:sub(rails#camelize(a:0 ? a:1 : ''), '^[^:]*::', ''), '!.*', '')
   return rails#buffer().open_command(a:cmd, a:0 ? a:1 : '', 'spec', [
-        \ {'pattern': 'spec/*_spec.rb', 'template': "require 'spec_helper'\n\ndescribe ".describe." do\nend"},
-        \ {'pattern': 'spec/spec_helper.rb'}])
+        \ {'pattern': 'spec/*_spec.rb', 'template': "require 'rails_helper'\n\ndescribe ".describe." do\nend"},
+        \ {'pattern': 'spec/spec_helper.rb'},
+        \ {'pattern': 'spec/rails_helper.rb'}])
 endfunction
 
 " }}}1


### PR DESCRIPTION
As of Rspec 3 both rails_helper and spec_helper get generated. For most rails specs a user should be requiring rails_helper by default as opposed to spec_helper.