### PR TITLE
Check for `dir` existence in rails#buffer_setup()

### DIFF
--- a/autoload/rails.vim
+++ b/autoload/rails.vim
@@ -5072,7 +5072,7 @@ function! rails#buffer_setup() abort
   endif
 
   let dispatch = self.projected('dispatch')
-  if !empty(dispatch) && exists(dir)
+  if !empty(dispatch) && exists('dir') && exists(dir)
     call self.setvar('dispatch', dir . dispatch[0])
   elseif self.name() =~# '^public'
     call self.setvar('dispatch', ':Preview')


### PR DESCRIPTION
This is a naive fix, that checks for `dir` existence before using it.
It takes care or a situation where `self.projected('dispatch')`
return value is not empty but `exists('*dispatch#dir_opt')` is false.

While this falls into a shouldn't happen territory,
it should be checked against nonetheless.