### PR TITLE
Remove cache 'has' method from add_methods

### DIFF
--- a/autoload/rails.vim
+++ b/autoload/rails.vim
@@ -3733,7 +3733,7 @@ function! s:cache_set(key, value, ...) dict abort
   let self.dict[a:key] = [a:value] + a:000
 endfunction
 
-call s:add_methods('cache', ['clear','needs','has','get','set'])
+call s:add_methods('cache', ['clear','needs','get','set'])
 
 let s:app_prototype.cache = s:cache_prototype
 


### PR DESCRIPTION
The function _cache_has_ has been removed in commit https://github.com/tpope/vim-rails/commit/a36c7764760c12dcec533c0c9027e7312c513f45

It is still present in the add_methods, causing an error on loading.