### PR TITLE
Fix get_binding_for(pid) for Rpreview

### DIFF
--- a/autoload/rails.vim
+++ b/autoload/rails.vim
@@ -1825,11 +1825,11 @@ function! rails#get_binding_for(pid) abort
     let lsof = '/usr/sbin/lsof'
   endif
   if exists('lsof')
-    let output = system(lsof.' -an -i4tcp -sTCP:LISTEN -p'.a:pid)
+    let output = system(lsof.' -anP -i4tcp -sTCP:LISTEN -p'.a:pid)
     let binding = matchstr(output, '\S\+:\d\+\ze\s\+(LISTEN)\n')
     let binding = s:sub(binding, '^\*', '0.0.0.0')
     if empty(binding)
-      let output = system(lsof.' -an -i6tcp -sTCP:LISTEN -p'.a:pid)
+      let output = system(lsof.' -anP -i6tcp -sTCP:LISTEN -p'.a:pid)
       let binding = matchstr(output, '\S\+:\d\+\ze\s\+(LISTEN)\n')
       let binding = s:sub(binding, '^\*', '[::]')
     endif


### PR DESCRIPTION
:Preview can not get the right port on my Macbook.
And I find out the `lsof` command gets the port name than the port number.

```
~/workspace/smart $ lsof -an -iTCP -sTCP:LISTEN -p23663
COMMAND   PID     USER   FD   TYPE             DEVICE SIZE/OFF NODE NAME
ruby    23663 lingceng   33u  IPv4 0xce7caf9daa1e02f5      0t0  TCP *:exlm-agent (LISTEN)
```

I add a `-P` option to fix it.
This option inhibits the conversion of port numbers to port names for network files.
```
~/workspace/smart $ lsof -anP -iTCP -sTCP:LISTEN -p23663
COMMAND   PID     USER   FD   TYPE             DEVICE SIZE/OFF NODE NAME
ruby    23663 lingceng   33u  IPv4 0xce7caf9daa1e02f5      0t0  TCP *:3002 (LISTEN)
```

See:
https://explainshell.com/explain?cmd=lsof+-anP+-iTCP+-sTCP%3ALISTEN+-p122
https://debian-administration.org/article/184/How_to_find_out_which_process_is_listening_upon_a_port