### PR TITLE
Remove unused 'format' variable.

### DIFF
--- a/autoload/rails.vim
+++ b/autoload/rails.vim
@@ -2304,7 +2304,6 @@ endfunction
 
 function! s:ruby_cfile() abort
   let buffer = rails#buffer()
-  let format = s:format()
 
   let res = s:findit('\v\s*<require\s*\(=\s*File.expand_path\([''"]../(\f+)[''"],\s*__FILE__\s*\)',expand('%:p:h').'/\1')
   if res != ""|return simplify(res.(res !~ '\.[^\/.]\+$' ? '.rb' : ''))|endif


### PR DESCRIPTION
It is no longer used in the function since commit 2d6558125cce7fcf1740d58870bda04eb66d3851.

I came across this while profiling `gf` on a very large ruby file (> 5000 lines). It was taking over 8 seconds. Turns out that the format function ends up calling the `readable_line_count` function > 5000 times, taking about 4 seconds in total. And the `buffer_getline` function also ended up being called about 20,000 times taking about 4 seconds as well.

Removing the storage of this unused variable seems to deflect the issue.

Please let me know if anything else needs to be done to get this merged. Thanks!