### PR TITLE
Fix :R in namespaced models

### DIFF
--- a/autoload/rails.vim
+++ b/autoload/rails.vim
@@ -742,7 +742,7 @@ function! s:readable_calculate_file_type() dict abort
     let r = "model-concern"
   elseif f =~# '^app/models/'
     let top = "\n".join(s:readfile(full_path,50),"\n")
-    let class = matchstr(top,"\n".'class\s\+\S\+\s*<\s*^\zs\S\+\>')
+    let class = matchstr(top,"\n".'class\s\+\S\+\s*<\s*\<\zs\S\+\>')
     let type = tolower(matchstr(class, '^Application\zs[A-Z]\w*$\|^Acti\w\w\zs[A-Z]\w*\ze::Base'))
     if type ==# 'mailer' || f =~# '_mailer\.rb$'
       let r = 'mailer'


### PR DESCRIPTION
In the case of namespaced models, eg.

    class Hello::World < ActiveRecord::Base
    end

the current regex would not recognize it as being a descendant of
ActiveRecord::Base, so hitting `:R` in such a model, would take you to the test/spec-file, and not, as exptected, the schema.

This PR basically reverts this line to the state prior to
01f66494cc1343b479b82b125dcaa60b5fc3cc43.

As I could not infer why the line was changed in the above commit, I'm not sure if this change breaks something else.

(And thank you, Tim, for your awesome work!)