### PR TITLE
Detect rails5 via railties

### DIFF
--- a/autoload/rails.vim
+++ b/autoload/rails.vim
@@ -901,7 +901,7 @@ function! s:app_has(feature) dict
 endfunction
 
 function! s:app_has_rails5() abort dict
-  let gemdir = get(self.gems(), 'rails')
+  let gemdir = get(self.gems(), 'railties')
   return self.has('rails5') || gemdir =~# '-\%([5-9]\|\d\d\+\)\.[^\/]*$'
 endfunction
 


### PR DESCRIPTION
We don't use `gem "rails"` in our Gemfile -- we don't want all of rails. We require "actionpack" etc specifically. But [railties](http://rubygems.org/gems/railties) is the core, required by all parts of rails, and the home of the `rails` command, so maybe it's a good choice for detection?