### PR TITLE
Add raise_error to syntax highlighting

### DIFF
--- a/after/syntax/ruby/rails.vim
+++ b/after/syntax/ruby/rails.vim
@@ -153,6 +153,7 @@ if s:path =~# '/spec/.*_spec\.rb$'
   syn keyword rubyTestMacro it example specify scenario include_examples include_context it_should_behave_like it_behaves_like
   syn keyword rubyComment xcontext xdescribe xfeature containedin=rubyKeywordAsMethod
   syn keyword rubyComment xit xexample xspecify xscenario
+  syn keyword RubyAssertion raise_error
 endif
 if s:path =~# '/spec/.*_spec\.rb$\|/features/step_definitions/.*\.rb$'
   syn keyword rubyAssertion pending skip expect is_expected expect_any_instance_of allow allow_any_instance_of


### PR DESCRIPTION
Add syntax highlighting to raise_error RSpec method
https://www.rubydoc.info/github/rspec/rspec-expectations/RSpec/Matchers:raise_error