### PR TITLE
Add skip_forgery_protection to syntax highlighting

### DIFF
--- a/after/syntax/ruby/rails.vim
+++ b/after/syntax/ruby/rails.vim
@@ -83,7 +83,7 @@ endif
 
 if s:path =~# '/app/controllers/.*\.rb$'
   syn keyword rubyHelper params request response session headers cookies flash
-  syn keyword rubyMacro protect_from_forgery
+  syn keyword rubyMacro protect_from_forgery skip_forgery_protection
   syn match   rubyMacro '\<respond_to\>\ze[( ] *[:*]'
   syn match   rubyResponse '\<respond_to\>\ze[( ] *\%([&{]\|do\>\)'
   syn keyword rubyResponse render head redirect_to redirect_back respond_with send_data send_file


### PR DESCRIPTION
Just adding syntax highlighting for `skip_forgery_protection`