### PR TITLE
`:Extract [partial_name]` shows message `No such directory` with file `app/views/layouts/application.html.erb`

### DIFF
--- a/autoload/rails.vim
+++ b/autoload/rails.vim
@@ -3742,14 +3742,10 @@ function! s:ViewExtract(bang, mods, first, last, file) abort
   let ext = expand("%:e")
   let file = s:sub(a:file, '%(/|^)\zs_\ze[^/]*$','')
   if rails#buffer().type_name('view-layout')
-    if rails#buffer().name() =~# '^app/views/layouts/application\>'
-      let curdir = 'app/views/shared'
-      if file !~ '/'
-        let file = "shared/" .file
-      endif
-    else
-      let curdir = s:sub(rails#buffer().name(),'.*<app/views/layouts/(.*)%(\.\w*)$','app/views/\1')
+    if file !~ '/'
+      let file = "application/" .file
     endif
+    let curdir = s:sub(rails#buffer().name(),'.*<app/views/layouts/(.*)%(\.\w*)$','app/views/\1')
   else
     let curdir = fnamemodify(rails#buffer().name(),':h')
   endif


### PR DESCRIPTION
Problem
--
`:Extract [partial_name]` shows message `No such directory` with file `app/views/layouts/application.html.erb`

Expected
--
- creates file `[partial_name]` in `app/views/application/`

Why
--

~~rails partials path has changed.~~
`app/views/shared` not found for recent Rails versions.

```
Rails 3.1, Rails 4, Rails 5 and whatever comes next

app/views/application
The engine searches this path automatically if the view is not found in the controller path.

Rails 3 and prior

app/views/shared
The engine does NOT search this path automatically.
```

Info
--
- This makes app/views/application/ a great place for your shared partials, which can then be rendered in your ERB as such: https://edgeguides.rubyonrails.org/layouts_and_rendering.html
- dry - Where to put partials shared by the whole application in Rails? - Stack Overflow https://stackoverflow.com/questions/2384631/where-to-put-partials-shared-by-the-whole-application-in-rails