### PR TITLE
Add support for app_db_url with nested config

### DIFF
--- a/autoload/rails.vim
+++ b/autoload/rails.vim
@@ -4206,6 +4206,7 @@ function! s:app_db_url(...) dict abort
     endif
   endif
   if !empty(config)
+    call filter(config, 'type(v:val) != type([]) && type(v:val) != type({})')
     let url .= '?' . join(map(items(config), 'v:val[0]."=".s:url_encode(v:val[1])'), '&')
   endif
   return url


### PR DESCRIPTION
In the case of a database.yml with nested configuration, e.g.

```yaml
development:
  variables:
    sql_mode: NO_AUTO_CREATE_USER
```

ignore nested values, like `dbconsole` does.