### PR TITLE
Add missing Minitests assertions

### DIFF
--- a/after/syntax/ruby/rails.vim
+++ b/after/syntax/ruby/rails.vim
@@ -139,8 +139,15 @@ if s:path =~# '/config/routes\>.*\.rb$'
 endif
 
 if s:path =~# '/test\%(/\|/.*/\)test_[^\/]*\.rb$\|/test/.*_test\.rb$\|/features/step_definitions/.*\.rb$'
-  syn keyword rubyAssertion refute refute_empty refute_equal refute_in_delta refute_in_epsilon refute_includes refute_instance_of refute_kind_of refute_match refute_nil refute_operator refute_predicate refute_respond_to refute_same
-  syn keyword rubyAssertion assert assert_block assert_equal assert_includes assert_in_delta assert_instance_of assert_kind_of assert_match assert_nil assert_no_match assert_not assert_not_equal assert_not_includes assert_not_nil assert_not_same assert_nothing_raised assert_nothing_thrown assert_operator assert_raise assert_respond_to assert_same assert_send assert_throws
+  " refute_* <=> assert_* <=> assert_not_*
+  syn keyword rubyAssertion refute     refute_empty     refute_equal     refute_in_delta     refute_in_epsilon     refute_includes     refute_instance_of     refute_kind_of     refute_match    refute_nil     refute_operator     refute_predicate     refute_respond_to     refute_same
+  syn keyword rubyAssertion assert     assert_empty     assert_equal     assert_in_delta     assert_in_epsilon     assert_includes     assert_instance_of     assert_kind_of     assert_match    assert_nil     assert_operator     assert_predicate     assert_respond_to     assert_same
+  syn keyword rubyAssertion assert_not assert_not_empty assert_not_equal assert_not_in_delta assert_not_in_epsilon assert_not_includes assert_not_instance_of assert_not_kind_of assert_no_match assert_not_nil assert_not_operator assert_not_predicate assert_not_respond_to assert_not_same
+  " assert_* <=> assert_not_*
+  syn keyword rubyAssertion assert_raises         assert_send     assert_throws
+  syn keyword rubyAssertion assert_nothing_raised assert_not_send assert_nothing_thrown
+  " assert_*
+  syn keyword rubyAssertion assert_raise assert_block assert_mock assert_output assert_raise_with_message assert_silent
   syn keyword rubyAssertion flunk
 endif
 


### PR DESCRIPTION
As a references were used following resources:

* http://docs.seattlerb.org/minitest/Minitest/Assertions.html
* https://ruby-doc.org/stdlib-2.1.1/libdoc/test/unit/rdoc/Test/Unit/Assertions.html
* https://edgeguides.rubyonrails.org/testing.html
  - 2.4 Available Assertions

New assertions:

```ruby
assert_empty
assert_in_epsilon
assert_mock
assert_not_empty
assert_not_in_delta
assert_not_in_epsilon
assert_not_instance_of
assert_not_kind_of
assert_not_operator
assert_not_predicate
assert_not_respond_to
assert_not_send
assert_output
assert_predicate
assert_raises
assert_raise_with_message
assert_silent
```