### PR TITLE
Add syntax highlight for ActionMailer assertions

### DIFF
--- a/after/syntax/ruby/rails.vim
+++ b/after/syntax/ruby/rails.vim
@@ -177,6 +177,7 @@ if rails#buffer().type_name('test')
   syn keyword rubyTestMacro test setup teardown
   syn keyword rubyAssertion assert_difference assert_no_difference
   syn keyword rubyAssertion assert_changes    assert_no_changes
+  syn keyword rubyAssertion assert_emails assert_enqueued_emails assert_no_emails assert_no_enqueued_emails
   syn keyword rubyTestAction travel travel_to travel_back
 endif
 if rails#buffer().type_name('test-controller', 'test-integration', 'test-system')


### PR DESCRIPTION
Reference: https://api.rubyonrails.org/v5.1/classes/ActionMailer/TestHelper.html

```ruby
class ContactTest < ActiveSupport::TestCase
  include ActionMailer::TestHelper

  test 'sending mail' do
    assert_enqueued_emails 1 do
      ContactMailer.welcome.deliver_later
    end
  end
end
```