### PR TITLE
Add highlight support for action_cable_meta_tag

### DIFF
--- a/after/syntax/ruby/rails.vim
+++ b/after/syntax/ruby/rails.vim
@@ -52,7 +52,7 @@ endif
 
 if s:path =~# '/app/helpers/.*_helper\.rb$\|/app/views/'
   syn keyword rubyViewHelper
-        \ action_name asset_pack_path asset_path asset_url atom_feed audio_path audio_tag audio_url auto_discovery_link_tag
+        \ action_cable_meta_tag action_name asset_pack_path asset_path asset_url atom_feed audio_path audio_tag audio_url auto_discovery_link_tag
         \ button_tag button_to
         \ cache cache_fragment_name cache_if cache_unless capture cdata_section check_box check_box_tag collection_check_boxes collection_radio_buttons collection_select color_field color_field_tag compute_asset_extname compute_asset_host compute_asset_path concat content_tag content_tag_for controller controller_name controller_path convert_to_model cookies csp_meta_tag csrf_meta_tag csrf_meta_tags current_cycle cycle
         \ date_field date_field_tag date_select datetime_field datetime_field_tag datetime_local_field datetime_local_field_tag datetime_select debug distance_of_time_in_words distance_of_time_in_words_to_now div_for dom_class dom_id


### PR DESCRIPTION
Pretty self-explanatory, this helper is not currently highlighted.