### PR TITLE
Make `gf` mapping work with SpaceVim

### DIFF
--- a/autoload/rails.vim
+++ b/autoload/rails.vim
@@ -4825,7 +4825,7 @@ call s:add_methods('app', ['internal_load_path'])
 nnoremap <SID>: :<C-U><C-R>=v:count ? v:count : ''<CR>
 function! s:map_gf() abort
   let pattern = '^$\|_gf(v:count\|[Rr]uby\|[Rr]ails'
-  if mapcheck('gf', 'n') =~# pattern
+  if mapcheck('gf', 'n') =~# pattern.'\|^gf$'
     nmap <buffer><silent> gf         <SID>:find <Plug><cfile><CR>
     let b:undo_ftplugin .= "|sil! exe 'nunmap <buffer> gf'"
   endif


### PR DESCRIPTION
SpaceVim includes a [`nnoremap gf gf`](https://github.com/SpaceVim/SpaceVim/blob/v1.4.0/autoload/SpaceVim/mapping/g.vim#L98), in order to clobber a mapping it installs for the `g` prefix, which displays a "guide" for the commands starting with `g`. (They do the same for the mappings with the `z` prefix.)

This ends up preventing vim-rails from installing a `gf` mapping of itself, since it uses a mapcheck() to only install a mapping when either none exists or a mapping it knowingly wants to override is present. But the mapping to itself from SpaceVim prevents that check from succeeding, which in turn prevents vim-rails from installing its own `gf` mapping.

This affects `gf`, but not `<C-W>f` or `<C-W>gf` which work as expected.

In order to work around this problem, update the pattern used by the mapcheck() checking for the `gf` mapping to also succeed when the mapped expression matches `gf` exactly.

Tested on `Pos*t.first`, confirmed that it works same as `<C-W>f` would work. Also checked output of `:map gf` on SpaceVim with vim-rails, which matches the expected:

```
n  gf           @<SNR>183_:find <Plug><cfile><CR>
n  gf          * gf
n  g             [G]
```

This issue was originally raised on StackExchange: [How to get tpope/vim-rails gf command to work with SpaceVim?](https://vi.stackexchange.com/q/20856/18609)

And about the weird mapping of SpaceVim: [Why would you use `nnoremap gf gf` as SpaceVim does?](https://vi.stackexchange.com/q/25224/18609)
