### PR TITLE
Add rspec focused keywords to syntax

### DIFF
--- a/after/syntax/ruby/rails.vim
+++ b/after/syntax/ruby/rails.vim
@@ -17,6 +17,7 @@ hi def link rubyUserAssertion               rubyAssertion
 hi def link rubyAssertion                   rubyException
 hi def link rubyTestAction                  rubyControl
 hi def link rubyHelper                      Function
+hi def link rubyDebug                       Debug
 
 let s:has_app = exists('*RailsDetect') && RailsDetect()
 let s:path = tr(expand('%:p'), '\', '/')
@@ -156,9 +157,9 @@ if s:path =~# '/spec/.*_spec\.rb$'
   syn match rubyTestMacro '\<subject\>!\=\ze\s*\%([({&:]\|do\>\)'
   syn keyword rubyTestMacro before after around background setup teardown
   syn keyword rubyTestMacro context describe feature shared_context shared_examples shared_examples_for containedin=rubyKeywordAsMethod
-  syn keyword rubyTestMacro fcontext fdescribe containedin=rubyKeywordAsMethod
   syn keyword rubyTestMacro it example specify scenario include_examples include_context it_should_behave_like it_behaves_like
-  syn keyword rubyTestMacro fit fexample fspecify
+  syn keyword rubyDebug fcontext fdescribe containedin=rubyKeywordAsMethod
+  syn keyword rubyDebug fit fexample fspecify
   syn keyword rubyComment xcontext xdescribe xfeature containedin=rubyKeywordAsMethod
   syn keyword rubyComment xit xexample xspecify xscenario
 endif

--- a/after/syntax/ruby/rails.vim
+++ b/after/syntax/ruby/rails.vim
@@ -156,7 +156,9 @@ if s:path =~# '/spec/.*_spec\.rb$'
   syn match rubyTestMacro '\<subject\>!\=\ze\s*\%([({&:]\|do\>\)'
   syn keyword rubyTestMacro before after around background setup teardown
   syn keyword rubyTestMacro context describe feature shared_context shared_examples shared_examples_for containedin=rubyKeywordAsMethod
+  syn keyword rubyTestMacro fcontext fdescribe containedin=rubyKeywordAsMethod
   syn keyword rubyTestMacro it example specify scenario include_examples include_context it_should_behave_like it_behaves_like
+  syn keyword rubyTestMacro fit fexample fspecify
   syn keyword rubyComment xcontext xdescribe xfeature containedin=rubyKeywordAsMethod
   syn keyword rubyComment xit xexample xspecify xscenario
 endif


### PR DESCRIPTION
RSpec has some [extra methods](https://github.com/rspec/rspec-core/blob/main/lib/rspec/core/example_group.rb#L302) to run focused tests, could we add those too so there's syntax highlighting? 