### PR TITLE
Default controller projection to ApplicationController

### DIFF
--- a/autoload/rails.vim
+++ b/autoload/rails.vim
@@ -4360,6 +4360,9 @@ let s:default_projections = {
       \    ],
       \    "type": "controller"
       \  },
+      \  "app/controllers/application_controller.rb": {
+      \    "type": "controller"
+      \  },
       \  "app/controllers/concerns/*.rb": {
       \    "affinity": "controller",
       \    "template": [


### PR DESCRIPTION
Similar to how `:Einitializer` with no arguments defaults to the routes file, `:Econtroller` with no arguments should default to `ApplicationController`. This seems like a reasonable default because AFAICT all Rails applications are generated with this as the default top-level controller ([even with the `--api` option](https://guides.rubyonrails.org/api_app.html)).

This PR has the side effect of creating `application_controller.rb` if it doesn't exist. That seems unexpected to me, but I couldn't figure out an implementation that doesn't do that.