### PR TITLE
Fix “E54: Unmatched (” when jumping to related from a `.sql` file

### DIFF
--- a/autoload/rails.vim
+++ b/autoload/rails.vim
@@ -405,7 +405,7 @@ function! s:readable_last_method(start) dict abort
     let string = matchstr(line,'^\s*\w\+\s*\([''"]\)\zs.*\ze\1')
     return 'test_'.s:gsub(string,' +','_')
   elseif lnum
-    return s:sub(matchstr(line,'\%('.self.define_pattern().'\)\zs\h\%(\k\|[:.]\)*[?!=]\='),':$','')
+    return s:sub(matchstr(line,'\%('.self.define_pattern().'\m\)\zs\h\%(\k\|[:.]\)*[?!=]\='),':$','')
   else
     return ""
   endif


### PR DESCRIPTION
This PR fixes the following error when invoking `:R` from a `.sql` file:

```
Error detected while processing function <SNR>143_Related[1]..<SNR>143_AR[54]..<SNR>143_readable_alternate[1]..<SNR>143_readable_alternate_candidates[2]..<SNR>143_readable_placeholders[5]..<SNR>143_readable_last_method:
line    7:
E54: Unmatched (
```

The problem is the `s:sql_define` pattern sets `\v` (very magic mode) which is then embedded into a `matchstr` pattern inside `s:readable_last_method` which does not expect the magic mode to the changed from the default.

I saw two options for solving this:

1. update the `s:sql_define` pattern to reset back to magic mode (`\m`), or
2. update `s:readable_last_method` to reset back to magic mode (`\m`) after embedding `self.define_pattern()`

The second option seemed to be more robust against other pattern inputs and I did not see `s:sql_define` being used as a part of other patterns elsewhere.