### PR TITLE
Add possibility to prevent :A default mapping

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -102,6 +102,11 @@ version only.
 It got yanked after increasing contention over JavaScript.  Check out
 [sleuth.vim](https://github.com/tpope/vim-sleuth).
 
+> :A like commands conflicts with vim-projectionist. Can I disable them?
+
+Yes, there's an option, which disables those commands:
+`let vim_rails_map_buf_nav_commands = 0
+`
 ## Self-Promotion
 
 Like rails.vim? Follow the repository on

--- a/README.markdown
+++ b/README.markdown
@@ -105,7 +105,7 @@ It got yanked after increasing contention over JavaScript.  Check out
 > :A like commands conflicts with vim-projectionist. Can I disable them?
 
 Yes, there's an option, which disables those commands:
-`let vim_rails_map_buf_nav_commands = 0
+`let g:vim_rails_map_buf_nav_commands = 0
 `
 ## Self-Promotion
 

--- a/README.markdown
+++ b/README.markdown
@@ -105,8 +105,10 @@ It got yanked after increasing contention over JavaScript.  Check out
 > :A like commands conflicts with vim-projectionist. Can I disable them?
 
 Yes, there's an option, which disables those commands:
-`let g:vim_rails_map_buf_nav_commands = 0
-`
+```
+let g:vim_rails_map_alternative_jump_commands = 0
+let g:vim_rails_map_related_jump_commands = 0
+```
 ## Self-Promotion
 
 Like rails.vim? Follow the repository on

--- a/autoload/rails.vim
+++ b/autoload/rails.vim
@@ -2160,6 +2160,10 @@ endfunction
 " Navigation {{{1
 
 function! s:BufNavCommands()
+  if !get(g:, 'vim_rails_map_buf_nav_commands', 1)
+    return
+  endif
+
   command! -buffer -bar -nargs=* -range=0 -complete=customlist,s:Complete_alternate A   exe s:Alternate('<mods> E<bang>',<line1>,<line2>,<count>,<f-args>)
   command! -buffer -bar -nargs=* -range=0 -complete=customlist,s:Complete_alternate AE  exe s:Alternate('<mods> E<bang>',<line1>,<line2>,<count>,<f-args>)
   command! -buffer -bar -nargs=* -range=0 -complete=customlist,s:Complete_alternate AS  exe s:Alternate('<mods> S<bang>',<line1>,<line2>,<count>,<f-args>)

--- a/autoload/rails.vim
+++ b/autoload/rails.vim
@@ -2160,23 +2160,24 @@ endfunction
 " Navigation {{{1
 
 function! s:BufNavCommands()
-  if !get(g:, 'vim_rails_map_buf_nav_commands', 1)
-    return
+  if get(g:, 'vim_rails_map_alternative_jump_commands', 1)
+    command! -buffer -bar -nargs=* -range=0 -complete=customlist,s:Complete_alternate A   exe s:Alternate('<mods> E<bang>',<line1>,<line2>,<count>,<f-args>)
+    command! -buffer -bar -nargs=* -range=0 -complete=customlist,s:Complete_alternate AE  exe s:Alternate('<mods> E<bang>',<line1>,<line2>,<count>,<f-args>)
+    command! -buffer -bar -nargs=* -range=0 -complete=customlist,s:Complete_alternate AS  exe s:Alternate('<mods> S<bang>',<line1>,<line2>,<count>,<f-args>)
+    command! -buffer -bar -nargs=* -range=0 -complete=customlist,s:Complete_alternate AV  exe s:Alternate('<mods> V<bang>',<line1>,<line2>,<count>,<f-args>)
+    command! -buffer -bar -nargs=* -range=0 -complete=customlist,s:Complete_alternate AT  exe s:Alternate('<mods> T<bang>',<line1>,<line2>,<count>,<f-args>)
+    command! -buffer -bar -nargs=* -range=0 -complete=customlist,s:Complete_edit      AD  exe s:Alternate('<mods> D<bang>',<line1>,<line2>,<count>,<f-args>)
+    command! -buffer -bar -nargs=* -range=0 -complete=customlist,s:Complete_edit      AR  exe s:Alternate('<mods> D<bang>',<line1>,<line2>,<count>,<f-args>)
   endif
 
-  command! -buffer -bar -nargs=* -range=0 -complete=customlist,s:Complete_alternate A   exe s:Alternate('<mods> E<bang>',<line1>,<line2>,<count>,<f-args>)
-  command! -buffer -bar -nargs=* -range=0 -complete=customlist,s:Complete_alternate AE  exe s:Alternate('<mods> E<bang>',<line1>,<line2>,<count>,<f-args>)
-  command! -buffer -bar -nargs=* -range=0 -complete=customlist,s:Complete_alternate AS  exe s:Alternate('<mods> S<bang>',<line1>,<line2>,<count>,<f-args>)
-  command! -buffer -bar -nargs=* -range=0 -complete=customlist,s:Complete_alternate AV  exe s:Alternate('<mods> V<bang>',<line1>,<line2>,<count>,<f-args>)
-  command! -buffer -bar -nargs=* -range=0 -complete=customlist,s:Complete_alternate AT  exe s:Alternate('<mods> T<bang>',<line1>,<line2>,<count>,<f-args>)
-  command! -buffer -bar -nargs=* -range=0 -complete=customlist,s:Complete_edit      AD  exe s:Alternate('<mods> D<bang>',<line1>,<line2>,<count>,<f-args>)
-  command! -buffer -bar -nargs=* -range=0 -complete=customlist,s:Complete_edit      AR  exe s:Alternate('<mods> D<bang>',<line1>,<line2>,<count>,<f-args>)
-  command! -buffer -bar -nargs=* -range=0 -complete=customlist,s:Complete_related   R   exe   s:Related('<mods> E<bang>',<line1>,<line2>,<count>,<f-args>)
-  command! -buffer -bar -nargs=* -range=0 -complete=customlist,s:Complete_related   RE  exe   s:Related('<mods> E<bang>',<line1>,<line2>,<count>,<f-args>)
-  command! -buffer -bar -nargs=* -range=0 -complete=customlist,s:Complete_related   RS  exe   s:Related('<mods> S<bang>',<line1>,<line2>,<count>,<f-args>)
-  command! -buffer -bar -nargs=* -range=0 -complete=customlist,s:Complete_related   RV  exe   s:Related('<mods> V<bang>',<line1>,<line2>,<count>,<f-args>)
-  command! -buffer -bar -nargs=* -range=0 -complete=customlist,s:Complete_related   RT  exe   s:Related('<mods> T<bang>',<line1>,<line2>,<count>,<f-args>)
-  command! -buffer -bar -nargs=* -range=0 -complete=customlist,s:Complete_edit      RD  exe   s:Related('<mods> D<bang>',<line1>,<line2>,<count>,<f-args>)
+  if get(g:, 'vim_rails_map_related_jump_commands', 1)
+    command! -buffer -bar -nargs=* -range=0 -complete=customlist,s:Complete_related   R   exe   s:Related('<mods> E<bang>',<line1>,<line2>,<count>,<f-args>)
+    command! -buffer -bar -nargs=* -range=0 -complete=customlist,s:Complete_related   RE  exe   s:Related('<mods> E<bang>',<line1>,<line2>,<count>,<f-args>)
+    command! -buffer -bar -nargs=* -range=0 -complete=customlist,s:Complete_related   RS  exe   s:Related('<mods> S<bang>',<line1>,<line2>,<count>,<f-args>)
+    command! -buffer -bar -nargs=* -range=0 -complete=customlist,s:Complete_related   RV  exe   s:Related('<mods> V<bang>',<line1>,<line2>,<count>,<f-args>)
+    command! -buffer -bar -nargs=* -range=0 -complete=customlist,s:Complete_related   RT  exe   s:Related('<mods> T<bang>',<line1>,<line2>,<count>,<f-args>)
+    command! -buffer -bar -nargs=* -range=0 -complete=customlist,s:Complete_edit      RD  exe   s:Related('<mods> D<bang>',<line1>,<line2>,<count>,<f-args>)
+  endif
 endfunction
 
 function! s:jumpargs(file, jump) abort

--- a/doc/rails.txt
+++ b/doc/rails.txt
@@ -795,7 +795,7 @@ lib/rails/projections.json.
 					*g:vim_rails_map_buf_nav_commands*
 disables A AE AS AV AT AD AR R RE RS RV RT RD commands
 >
-	let vim_rails_map_buf_nav_commands = 0
+	let g:vim_rails_map_buf_nav_commands = 0
 <
 
 ABOUT					*rails-about* *rails-plugin-author*

--- a/doc/rails.txt
+++ b/doc/rails.txt
@@ -792,10 +792,15 @@ single project.
 
 Gem maintainers may also provide custom projections by placing them in
 lib/rails/projections.json.
-					*g:vim_rails_map_buf_nav_commands*
-disables A AE AS AV AT AD AR R RE RS RV RT RD commands
+					*g:vim_rails_map_alternative_jump_commands*
+disables A AE AS AV AT AD AR commands
 >
-	let g:vim_rails_map_buf_nav_commands = 0
+	let g:vim_rails_map_alternative_jump_commands = 0
+
+					g:vim_rails_map_related_jump_commands
+disables R RE RS RV RT RD commands
+>
+	let g:vim_rails_map_related_jump_commands = 0
 <
 
 ABOUT					*rails-about* *rails-plugin-author*

--- a/doc/rails.txt
+++ b/doc/rails.txt
@@ -792,6 +792,11 @@ single project.
 
 Gem maintainers may also provide custom projections by placing them in
 lib/rails/projections.json.
+					*g:vim_rails_map_buf_nav_commands*
+disables A AE AS AV AT AD AR R RE RS RV RT RD commands
+>
+	let vim_rails_map_buf_nav_commands = 0
+<
 
 ABOUT					*rails-about* *rails-plugin-author*
 


### PR DESCRIPTION
Hi. I'm posting a way of preventing the plugin from remapping A AE AS AV AT AD AR R RE RS RV RT RD commands.

I've beed using this workaround to keep vim-projectionist commands from being overridden.
It introduces new variable `g:vim_rails_map_buf_nav_commands` and defaults its value to 1, so it does not change behaviour of the plugin unless user sets `g:vim_rails_map_buf_nav_commands = 0` explicitly in his config

Consider merging this PR if you find it useful 😄 