### PR TITLE
Add configurable URI scheme for :Preview

### DIFF
--- a/autoload/rails.vim
+++ b/autoload/rails.vim
@@ -1737,6 +1737,7 @@ call s:add_methods('app', ['server_pid', 'server_binding'])
 
 function! s:Preview(bang, lnum, uri) abort
   let binding = rails#app().server_binding()
+  let uri_scheme = get(g:, 'rails_uri_scheme', 'http').'://'
   if empty(binding)
     let binding = '0.0.0.0:3000'
   endif
@@ -1746,12 +1747,12 @@ function! s:Preview(bang, lnum, uri) abort
   if uri =~ '://'
     "
   elseif uri =~# '^[[:alnum:]-]\+\.'
-    let uri = 'http://'.s:sub(uri, '^[^/]*\zs', matchstr(root, ':\d\+$'))
+    let uri = uri_scheme.s:sub(uri, '^[^/]*\zs', matchstr(root, ':\d\+$'))
   elseif uri =~# '^[[:alnum:]-]\+\%(/\|$\)'
     let domain = s:sub(binding, '^localhost>', 'lvh.me')
-    let uri = 'http://'.s:sub(uri, '^[^/]*\zs', '.'.domain)
+    let uri = uri_scheme.s:sub(uri, '^[^/]*\zs', '.'.domain)
   else
-    let uri = 'http://'.binding.'/'.s:sub(uri,'^/','')
+    let uri = uri_scheme.binding.'/'.s:sub(uri,'^/','')
   endif
   call s:initOpenURL()
   if (exists(':OpenURL') == 2) && !a:bang


### PR DESCRIPTION
By default, vim-rails uses http for localhost connections when using :Preview, however some projects I have been working on enforce https in the development environment.  This change allows you to override the http default to use https if desired with the g:rails_uri_scheme variable.

```vim
let g:rails_uri_scheme = 'https'
```