### PR TITLE
Add autodetected http/https protocols

### DIFF
--- a/autoload/rails.vim
+++ b/autoload/rails.vim
@@ -1992,7 +1992,6 @@ function! rails#get_binding_for(pid) abort
         return ''
       endif
       let uri_scheme = s:UriSchemeFor(binding)
-      return uri_scheme . s:sub(binding, '^([^[]*:.*):', '[\1]:')
     else
       let binding = ''
     endif

--- a/autoload/rails.vim
+++ b/autoload/rails.vim
@@ -1993,7 +1993,7 @@ function! rails#get_binding_for(pid) abort
       let binding = ''
     endif
   endif
-  let binding = substitute(binding, '^\(^[^[]*:.*):', '[\1]:', '')
+  let binding = substitute(binding, '^\(^[^[]*:.*\):', '[\1]:', '')
   if empty(binding)
     return ''
   endif

--- a/autoload/rails.vim
+++ b/autoload/rails.vim
@@ -1967,6 +1967,7 @@ function! rails#get_binding_for(pid) abort
   if empty(a:pid)
     return ''
   endif
+  let uri_scheme = 'http://'
   if has('win32')
     let output = system('netstat -anop tcp')
     let binding = matchstr(output, '\n\s*TCP\s\+\zs\S\+\ze\s\+\S\+\s\+LISTENING\s\+'.a:pid.'\>')
@@ -1991,7 +1992,6 @@ function! rails#get_binding_for(pid) abort
       if empty(binding)
         return ''
       endif
-      let uri_scheme = s:UriSchemeFor(binding)
     else
       let binding = ''
     endif
@@ -2000,21 +2000,13 @@ function! rails#get_binding_for(pid) abort
   if empty(binding)
     return ''
   endif
-  let uri_scheme = s:UriSchemeFor(binding)
-  return uri_scheme . binding
-endfunction
-
-function! s:UriSchemeFor(binding) abort
-  let uri_scheme = 'http://'
-
   if executable('curl')
-    let curl_result = system('curl -k --silent --head --fail https://'.a:binding)
+    let curl_result = system('curl -k --silent --head --fail https://'.binding)
     if len(matchstr(curl_result, '200 OK')) > 0
       let uri_scheme = 'https://'
     endif
   endif
-
-  return uri_scheme
+  return uri_scheme . binding
 endfunction
 
 function! s:ServerCommand(kill, bg, arg) abort

--- a/autoload/rails.vim
+++ b/autoload/rails.vim
@@ -1990,9 +1990,6 @@ function! rails#get_binding_for(pid) abort
     elseif executable('netstat')
       let output = system('netstat -antp')
       let binding = matchstr(output, '\S\+:\d\+\ze\s\+\S\+\s\+LISTEN\s\+'.a:pid.'/')
-      if empty(binding)
-        return ''
-      endif
     else
       let binding = ''
     endif

--- a/autoload/rails.vim
+++ b/autoload/rails.vim
@@ -1968,6 +1968,7 @@ function! rails#get_binding_for(pid) abort
     return ''
   endif
   let uri_scheme = 'http://'
+  let ssl_result = ''
   if has('win32')
     let output = system('netstat -anop tcp')
     let binding = matchstr(output, '\n\s*TCP\s\+\zs\S\+\ze\s\+\S\+\s\+LISTENING\s\+'.a:pid.'\>')
@@ -2001,10 +2002,12 @@ function! rails#get_binding_for(pid) abort
     return ''
   endif
   if executable('curl')
-    let curl_result = system('curl -k --silent --head --fail https://'.binding)
-    if len(matchstr(curl_result, '200 OK')) > 0
-      let uri_scheme = 'https://'
-    endif
+    let ssl_result = system('curl -k --silent --head --fail https://'.binding)
+  elseif executable('wget')
+    let ssl_result = system('wget --no-check-certificate --method=HEAD -q -S https://'.binding)
+  endif
+  if len(matchstr(ssl_result, '200 OK')) > 0
+    let uri_scheme = 'https://'
   endif
   return uri_scheme . binding
 endfunction

--- a/autoload/rails.vim
+++ b/autoload/rails.vim
@@ -1989,7 +1989,10 @@ function! rails#get_binding_for(pid) abort
     elseif executable('netstat')
       let output = system('netstat -antp')
       let binding = matchstr(output, '\S\+:\d\+\ze\s\+\S\+\s\+LISTEN\s\+'.a:pid.'/')
-      return empty(binding) ? '' : uri_scheme . s:sub(binding, '^([^[]*:.*):', '[\1]:')
+      if empty(binding)
+        return ''
+      endif
+      return uri_scheme . s:sub(binding, '^([^[]*:.*):', '[\1]:')
     else
       let binding = ''
     endif

--- a/autoload/rails.vim
+++ b/autoload/rails.vim
@@ -1967,6 +1967,7 @@ function! rails#get_binding_for(pid) abort
   if empty(a:pid)
     return ''
   endif
+  let uri_scheme = 'http://'
   if has('win32')
     let output = system('netstat -anop tcp')
     let binding = matchstr(output, '\n\s*TCP\s\+\zs\S\+\ze\s\+\S\+\s\+LISTENING\s\+'.a:pid.'\>')
@@ -1988,7 +1989,7 @@ function! rails#get_binding_for(pid) abort
     elseif executable('netstat')
       let output = system('netstat -antp')
       let binding = matchstr(output, '\S\+:\d\+\ze\s\+\S\+\s\+LISTEN\s\+'.a:pid.'/')
-      return empty(binding) ? '' : 'http://' . s:sub(binding, '^([^[]*:.*):', '[\1]:')
+      return empty(binding) ? '' : uri_scheme . s:sub(binding, '^([^[]*:.*):', '[\1]:')
     else
       let binding = ''
     endif
@@ -1997,7 +1998,7 @@ function! rails#get_binding_for(pid) abort
   if empty(binding)
     return ''
   endif
-  return 'http://' . binding
+  return uri_scheme . binding
 endfunction
 
 function! s:ServerCommand(kill, bg, arg) abort


### PR DESCRIPTION
This is in response to @tpope's response on PR #590 to allow https to be used for localhost connections using Preview.  There, he mentioned that he'd like the uri scheme protocol to be autodetected, which I appreciate.  I opted to use 'possible approach 3' to ps/grep for ssl://<binding> to see if it was being used or not.